### PR TITLE
Fix broken documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > "A true master teaches not by telling, but by refining." - The Skill Sensei
 
-Sensei automates the improvement of [Agent Skills](https://support.anthropic.com/en/articles/12512198-how-to-create-custom-skills) frontmatter compliance using the [Ralph loop pattern](https://github.com/soderlund/ralph) - iteratively improving skills until they reach Medium-High compliance with all tests passing.
+Sensei automates the improvement of [Agent Skills](https://support.anthropic.com/en/articles/12512198-how-to-create-custom-skills) frontmatter compliance using the [Ralph loop pattern](references/loop.md) - iteratively improving skills until they reach Medium-High compliance with all tests passing.
 
 ## Table of Contents
 
@@ -359,7 +359,7 @@ To reach High, add routing clarity:
 
 ### MCP Integration Checks
 
-When a skill's description contains `INVOKES:`, Sensei performs additional checks based on the [Skills, Tools & MCP Development Guide](https://github.com/spboyer/azure-mcp-v-skills/blob/main/skills-mcp-development-guide.md):
+When a skill's description contains `INVOKES:`, Sensei performs additional checks based on the [MCP Integration Patterns](references/mcp-integration.md):
 
 | Check | Purpose |
 |-------|---------|
@@ -504,7 +504,7 @@ git reset --soft HEAD~1  # Undo last commit
 
 ### Waza Trigger Tests
 
-Sensei supports [Waza](https://github.com/spboyer/waza) for trigger accuracy testing. See `references/test-templates/waza.md`.
+Sensei supports Waza-style trigger accuracy testing. See [the Waza test template](references/test-templates/waza.md).
 
 ### Reporting Issues
 
@@ -514,10 +514,10 @@ Open an issue with skill name, starting state, and `git log --oneline -10`.
 
 ## References
 
-- [Ralph Loop Pattern](https://github.com/soderlund/ralph) - Original Ralph loop implementation
+- [Ralph Loop Pattern](references/loop.md) - Sensei's iterative improvement workflow
 - [Anthropic Skills Documentation](https://support.anthropic.com/en/articles/12512198-how-to-create-custom-skills) - Writing guidance
-- [Skills, Tools & MCP Development Guide](https://github.com/spboyer/azure-mcp-v-skills/blob/main/skills-mcp-development-guide.md) - MCP integration best practices
-- [Waza Testing Framework](https://github.com/spboyer/waza) - Skill trigger accuracy testing
+- [MCP Integration Patterns](references/mcp-integration.md) - MCP integration best practices
+- [Waza Trigger Test Template](references/test-templates/waza.md) - Skill trigger accuracy testing
 - [GEPA](https://gepa-ai.github.io/gepa/) - Evolutionary optimization for skills
 - [skill-creator](https://github.com/anthropics/skills/tree/main/skills/skill-creator) - For creating new skills from scratch
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,7 +7,7 @@ description: "**WORKFLOW SKILL** — Iteratively improve skill frontmatter compl
 
 > "A true master teaches not by telling, but by refining."
 
-Automates skill frontmatter improvement using the [Ralph loop pattern](https://github.com/soderlund/ralph) - iteratively improving skills until they reach Medium-High compliance with passing tests.
+Automates skill frontmatter improvement using the [Ralph loop pattern](references/loop.md) - iteratively improving skills until they reach Medium-High compliance with passing tests.
 
 ## Help
 

--- a/demo-docs/QUICK-REFERENCE.md
+++ b/demo-docs/QUICK-REFERENCE.md
@@ -84,4 +84,4 @@ A: It has explicit triggers AND anti-triggers - minimum for good routing.
 
 - **Repo:** https://github.com/spboyer/sensei
 - **Anthropic Skills Docs:** https://support.anthropic.com/en/articles/12512198
-- **Ralph Loop:** https://github.com/soderlund/ralph
+- **Ralph Loop:** ../references/loop.md

--- a/docs/blog/sensei-launch.md
+++ b/docs/blog/sensei-launch.md
@@ -139,7 +139,7 @@ Score: **High.** Clear purpose. Explicit triggers. Anti-triggers drawing boundar
 
 This is the part that changes everything.
 
-Sensei doesn't hand you a list of violations and walk away. It uses the [Ralph loop pattern](https://github.com/soderlund/ralph) — an iterative improvement cycle that reads, scores, fixes, tests, and verifies until your skill reaches compliance. Automatically.
+Sensei doesn't hand you a list of violations and walk away. It uses the [Ralph loop pattern](../../references/loop.md) — an iterative improvement cycle that reads, scores, fixes, tests, and verifies until your skill reaches compliance. Automatically.
 
 Here's how the loop works: Sensei reads your SKILL.md and scores it. If it's below Medium-High, it scaffolds tests from templates, improves the frontmatter by adding triggers, anti-triggers, and routing clarity, then runs those tests to make sure the changes actually work. It checks your token budget. It shows you a before/after comparison. Then it asks: commit, create an issue, or skip?
 

--- a/references/mcp-integration.md
+++ b/references/mcp-integration.md
@@ -1,6 +1,6 @@
 # MCP Integration Patterns
 
-Best practices for skills that integrate with MCP tools, based on the [Skills, Tools & MCP Development Guide](https://github.com/spboyer/azure-mcp-v-skills/blob/main/skills-mcp-development-guide.md).
+Best practices for skills that integrate with MCP tools.
 
 ## The Hybrid Pattern
 
@@ -131,6 +131,6 @@ Call `azure-get_azure_bestpractices` with:
 
 ## Reference
 
-- [Full MCP Development Guide](https://github.com/spboyer/azure-mcp-v-skills/blob/main/skills-mcp-development-guide.md)
+- [MCP Integration Patterns](mcp-integration.md)
 - [MCP Protocol Specification](https://modelcontextprotocol.io/specification/latest)
-- [Waza Testing Framework](https://github.com/spboyer/waza)
+- [Waza Trigger Test Template](test-templates/waza.md)


### PR DESCRIPTION
## Summary
- Replace broken Ralph loop, MCP guide, and Waza GitHub links with repo-local documentation links
- Update repeated references in README, SKILL, reference, demo, and blog docs

## Validation
- Confirmed the reported broken URLs no longer appear in markdown docs
- Checked replacement local links exist
- Ran `npm run tokens -- check README.md SKILL.md references/mcp-integration.md demo-docs/QUICK-REFERENCE.md docs/blog/sensei-launch.md`

Fixes #6