### PR TITLE
Expose skill scorer as a library API

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,18 @@ npm run tokens -- score .
 npm run tokens -- compare HEAD~1
 ```
 
+---
+
+## Library Usage
+
+```ts
+import { scoreSkillContent } from '@spboyer/sensei/score';
+
+const result = scoreSkillContent(renderedSkillMarkdown, { path: 'skills/my-skill', moduleCount: 2 });
+```
+
+`path` is metadata; `moduleCount` defaults to `0`.
+
 ### GEPA Commands
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,12 +1,40 @@
 {
-  "name": "sensei",
+  "name": "@spboyer/sensei",
   "version": "1.3.0",
   "description": "AI-powered frontmatter compliance skill for GitHub Copilot",
-  "private": true,
   "type": "module",
   "scripts": {
+    "build": "npm --prefix scripts run build",
     "tokens": "node --import ./scripts/node_modules/tsx/dist/loader.mjs scripts/src/tokens/cli.ts",
-    "test": "cd scripts && npm test"
+    "test": "cd scripts && npm test",
+    "prepack": "npm run build",
+    "prepublishOnly": "npm run build && npm test"
+  },
+  "main": "./scripts/dist/score.js",
+  "types": "./scripts/dist/score.d.ts",
+  "exports": {
+    ".": {
+      "types": "./scripts/dist/score.d.ts",
+      "import": "./scripts/dist/score.js"
+    },
+    "./score": {
+      "types": "./scripts/dist/score.d.ts",
+      "import": "./scripts/dist/score.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "scripts/dist/score.js",
+    "scripts/dist/score.d.ts",
+    "scripts/dist/tokens/commands/score.js",
+    "scripts/dist/tokens/commands/score.d.ts",
+    "scripts/dist/tokens/commands/types.js",
+    "scripts/dist/tokens/commands/types.d.ts",
+    "README.md",
+    "LICENSE.txt"
+  ],
+  "publishConfig": {
+    "access": "public"
   },
   "keywords": [
     "copilot",

--- a/scripts/src/score.ts
+++ b/scripts/src/score.ts
@@ -1,0 +1,1 @@
+export * from './tokens/commands/score.js';

--- a/scripts/src/tokens/commands/index.ts
+++ b/scripts/src/tokens/commands/index.ts
@@ -2,5 +2,5 @@ export { count } from './count.js';
 export { check } from './check.js';
 export { suggest } from './suggest.js';
 export { compare } from './compare.js';
-export { scoreSkill } from './score.js';
+export * from './score.js';
 export * from './types.js';

--- a/scripts/src/tokens/commands/score.test.ts
+++ b/scripts/src/tokens/commands/score.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { scoreSkillContent as publicScoreSkillContent } from '../../score.js';
 import {
   checkModuleCount,
   classifyComplexity,
@@ -13,6 +14,7 @@ import {
   checkProceduralContent,
   checkOverSpecificity,
   scoreSkill,
+  scoreSkillContent,
   parseFrontmatter,
   checkFrontmatterStructure,
   checkAllowedFields,
@@ -330,6 +332,14 @@ describe('parseFrontmatter', () => {
     expect(fm!.description).toContain('Line one');
     expect(fm!.description).toContain('Line two');
   });
+
+  it('parses block scalar descriptions with chomping indicators', () => {
+    const content = '---\nname: my-skill\ndescription: |-\n  Line one.\n  Line two.\n---\n';
+    const fm = parseFrontmatter(content);
+    expect(fm!.description).toContain('Line one');
+    expect(fm!.description).toContain('Line two');
+    expect(fm!.description).not.toContain('|-');
+  });
 });
 
 describe('checkFrontmatterStructure', () => {
@@ -535,6 +545,58 @@ describe('checkVersionRecommendation', () => {
 // Integration: scoreSkill
 // ---------------------------------------------------------------------------
 
+describe('scoreSkillContent', () => {
+  const skillContent = [
+    '---',
+    'name: memory-skill',
+    'description: Deploy and configure applications. WHEN: deploy app, configure app.',
+    '---',
+    '',
+    '# Memory Skill',
+    '',
+    'Step 1: Build.',
+    'Step 2: Deploy.',
+    ''
+  ].join('\n');
+
+  it('scores in-memory content without a filesystem path', () => {
+    const result = scoreSkillContent(skillContent);
+
+    expect(result.skillPath).toBe('<memory>');
+    expect(result.moduleCount).toBe(0);
+    expect(result.tokenCount).toBeGreaterThan(0);
+    expect(result.checks).toHaveLength(9);
+
+    const specNames = result.specChecks.map(c => c.name);
+    expect(specNames).toContain('spec-frontmatter');
+    expect(specNames).toContain('spec-name');
+    expect(specNames).not.toContain('spec-dir-match');
+  });
+
+  it('uses optional path metadata for directory-name checks', () => {
+    const result = scoreSkillContent(skillContent, { path: '/skills/memory-skill' });
+    const dirCheck = result.specChecks.find(c => c.name === 'spec-dir-match');
+
+    expect(result.skillPath).toBe('/skills/memory-skill');
+    expect(dirCheck?.status).toBe('ok');
+  });
+
+  it('uses caller-provided module counts for module and complexity checks', () => {
+    const result = scoreSkillContent(skillContent, { moduleCount: 4 });
+
+    expect(result.moduleCount).toBe(4);
+    expect(result.complexity).toBe('comprehensive');
+    expect(result.checks.find(c => c.name === 'module-count')?.status).toBe('warning');
+  });
+
+  it('is exported from the public scorer entry point', () => {
+    const result = publicScoreSkillContent(skillContent);
+
+    expect(result.skillPath).toBe('<memory>');
+    expect(result.checks.map(c => c.name)).toContain('module-count');
+  });
+});
+
 describe('scoreSkill', () => {
   let tempDir: string;
 
@@ -570,8 +632,10 @@ describe('scoreSkill', () => {
     writeFileSync(join(refsDir, 'api.md'), '# API');
 
     const result = scoreSkill(tempDir);
+    const contentResult = scoreSkillContent(skillContent, { path: tempDir, moduleCount: 2 });
 
     expect(result.skillPath).toBe(tempDir);
+    expect(result).toEqual(contentResult);
     expect(result.checks).toHaveLength(9);
     expect(result.specChecks.length).toBeGreaterThan(0);
     expect(result.tokenCount).toBeGreaterThan(0);

--- a/scripts/src/tokens/commands/score.ts
+++ b/scripts/src/tokens/commands/score.ts
@@ -42,6 +42,22 @@ function listFilesRecursive(dir: string): string[] {
   return results;
 }
 
+/** Strip simple YAML scalar quotes from frontmatter values. */
+function normalizeFrontmatterValue(value: string): string {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function isBlockScalarMarker(value: string): boolean {
+  return /^[|>][+-]?$/.test(value);
+}
+
 /** Result of a single advisory check */
 export interface AdvisoryCheck {
   readonly name: string;
@@ -82,17 +98,17 @@ export function parseFrontmatter(content: string): ParsedFrontmatter | null {
     const keyMatch = line.match(/^(\w[\w-]*)\s*:\s*(.*)/);
     if (keyMatch) {
       if (currentKey) {
-        fields[currentKey] = currentValue.trim();
+        fields[currentKey] = normalizeFrontmatterValue(currentValue);
       }
       currentKey = keyMatch[1];
       const rawVal = keyMatch[2].trim();
-      currentValue = rawVal === '|' || rawVal === '>' ? '' : rawVal;
+      currentValue = isBlockScalarMarker(rawVal) ? '' : rawVal;
     } else if (currentKey && (line.startsWith('  ') || line.startsWith('\t'))) {
       currentValue += (currentValue ? '\n' : '') + line.trim();
     }
   }
   if (currentKey) {
-    fields[currentKey] = currentValue.trim();
+    fields[currentKey] = normalizeFrontmatterValue(currentValue);
   }
 
   return {
@@ -348,6 +364,17 @@ export interface ScoringResult {
   readonly tokenCount: number;
 }
 
+/** Public scorer result type for library consumers. */
+export type SkillScore = ScoringResult;
+
+/** Options for scoring in-memory SKILL.md content. */
+export interface ScoreSkillContentOptions {
+  /** Optional display path and directory-name context; content is never read from this path. */
+  readonly path?: string;
+  /** Optional caller-provided count of markdown files in references/. Defaults to 0. */
+  readonly moduleCount?: number;
+}
+
 /** Action verbs indicating procedural content */
 const ACTION_VERBS = [
   'process', 'extract', 'deploy', 'configure', 'analyze',
@@ -370,14 +397,20 @@ const PROCEDURE_KEYWORDS = [
  * 0-1: ok, 2-3: optimal, 4+: warning
  */
 export function checkModuleCount(skillDir: string): AdvisoryCheck {
-  const refsDir = join(skillDir, 'references');
-  let mdCount = 0;
+  return createModuleCountCheck(countReferenceModules(skillDir));
+}
 
-  if (existsSync(refsDir)) {
-    const files = listFilesRecursive(refsDir);
-    mdCount = files.filter(f => f.endsWith('.md')).length;
+function countReferenceModules(skillDir: string): number {
+  const refsDir = join(skillDir, 'references');
+  if (!existsSync(refsDir)) {
+    return 0;
   }
 
+  const files = listFilesRecursive(refsDir);
+  return files.filter(f => f.endsWith('.md')).length;
+}
+
+function createModuleCountCheck(mdCount: number): AdvisoryCheck {
   if (mdCount >= 4) {
     return {
       name: 'module-count',
@@ -727,6 +760,63 @@ export function checkCrossModelDensity(description: string): AdvisoryCheck[] {
 }
 
 /**
+ * Run all advisory checks on in-memory SKILL.md content.
+ */
+export function scoreSkillContent(content: string, opts: ScoreSkillContentOptions = {}): SkillScore {
+  const skillPath = opts.path ?? '<memory>';
+  const moduleCount = opts.moduleCount ?? 0;
+  const tokenCount = estimateTokens(content);
+  const moduleCountCheck = createModuleCountCheck(moduleCount);
+
+  const complexityCheck = classifyComplexity(tokenCount, moduleCount);
+  const complexity = complexityCheck.status === 'warning'
+    ? 'comprehensive'
+    : complexityCheck.status === 'optimal'
+      ? 'detailed'
+      : 'compact';
+
+  const fm = parseFrontmatter(content);
+  const description = fm?.description ?? '';
+
+  // Advisory checks (Sensei-original)
+  const checks: AdvisoryCheck[] = [
+    moduleCountCheck,
+    complexityCheck,
+    checkNegativeDeltaRisk(content),
+    checkProceduralContent(description),
+    checkOverSpecificity(content),
+    ...checkCrossModelDensity(description)
+  ];
+
+  // Spec compliance checks (agentskills.io)
+  const specChecks: AdvisoryCheck[] = [checkFrontmatterStructure(content)];
+  if (fm) {
+    specChecks.push(checkAllowedFields(fm.fields));
+    if (fm.name) {
+      specChecks.push(checkNameCompliance(fm.name));
+      if (opts.path) {
+        specChecks.push(checkDirectoryNameMatch(opts.path, fm.name));
+      }
+    }
+    if (fm.description !== undefined) {
+      specChecks.push(checkDescriptionCompliance(fm.description));
+    }
+    specChecks.push(checkCompatibilityCompliance(fm.compatibility));
+    specChecks.push(checkLicenseRecommendation(fm.fields));
+    specChecks.push(checkVersionRecommendation(fm.fields));
+  }
+
+  return {
+    skillPath,
+    checks,
+    specChecks,
+    complexity,
+    moduleCount,
+    tokenCount
+  };
+}
+
+/**
  * Run all advisory checks on a skill directory.
  */
 export function scoreSkill(skillDir: string): ScoringResult {
@@ -764,71 +854,9 @@ export function scoreSkill(skillDir: string): ScoringResult {
     };
   }
 
-  let content = '';
-  let description = '';
-
-  content = readFileSync(skillMdPath, 'utf-8');
-
-  // Extract description from frontmatter
-  const frontmatterMatch = content.match(/^---\s*\n([\s\S]*?)\n---/);
-  if (frontmatterMatch) {
-    const fmContent = frontmatterMatch[1];
-    const descMatch = fmContent.match(/description:\s*(?:[|>]-?)\s*\n([\s\S]*?)(?=\n\w+:|$)/);
-    if (descMatch) {
-      description = descMatch[1].replace(/^\s+/gm, '').trim();
-    } else {
-      // Try inline description (quoted string)
-      const inlineMatch = fmContent.match(/description:\s*["']?(.*?)["']?\s*$/m);
-      if (inlineMatch) {
-        description = inlineMatch[1].trim();
-      }
-    }
-  }
-
-  const tokenCount = estimateTokens(content);
-  const moduleCountCheck = checkModuleCount(skillDir);
-  const moduleCount = parseInt(moduleCountCheck.message.match(/(\d+)/)?.[1] ?? '0', 10);
-
-  const complexityCheck = classifyComplexity(tokenCount, moduleCount);
-  const complexity = complexityCheck.status === 'warning'
-    ? 'comprehensive'
-    : complexityCheck.status === 'optimal'
-      ? 'detailed'
-      : 'compact';
-
-  // Advisory checks (Sensei-original)
-  const checks: AdvisoryCheck[] = [
-    moduleCountCheck,
-    complexityCheck,
-    checkNegativeDeltaRisk(content),
-    checkProceduralContent(description),
-    checkOverSpecificity(content),
-    ...checkCrossModelDensity(description)
-  ];
-
-  // Spec compliance checks (agentskills.io)
-  const specChecks: AdvisoryCheck[] = [checkFrontmatterStructure(content)];
-  const fm = parseFrontmatter(content);
-  if (fm) {
-    specChecks.push(checkAllowedFields(fm.fields));
-    if (fm.name) {
-      specChecks.push(checkNameCompliance(fm.name));
-      specChecks.push(checkDirectoryNameMatch(skillDir, fm.name));
-    }
-    if (fm.description !== undefined) {
-      specChecks.push(checkDescriptionCompliance(fm.description));
-    }
-    specChecks.push(checkCompatibilityCompliance(fm.compatibility));
-    specChecks.push(checkLicenseRecommendation(fm.fields));
-    specChecks.push(checkVersionRecommendation(fm.fields));
-  }
-
-  return {
-    skillPath: skillDir,
-    checks,
-    specChecks,
-    complexity,
-    moduleCount,
-    tokenCount
-  };
+  const content = readFileSync(skillMdPath, 'utf-8');
+  return scoreSkillContent(content, {
+    path: skillDir,
+    moduleCount: countReferenceModules(skillDir)
+  });
 }


### PR DESCRIPTION
## Summary
- add pure `scoreSkillContent(content, opts?)` scoring for in-memory SKILL.md content
- keep `scoreSkill(skillDir)` as the filesystem-compatible wrapper
- add score-only package exports for `@spboyer/sensei/score`
- document library usage and cover content/path/module-count behavior in tests

Fixes #8

## Validation
- `npm test`
- `npm run build`
- `npm run tokens -- check README.md`
- `npm pack --dry-run --json`
- direct ESM import smoke test from `scripts/dist/score.js`