### PR TITLE
Improve external Sensei integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,42 +80,46 @@ Run sensei score my-skill-name
 
 Score-only mode runs without LLM calls.
 
-### Using Scripts Directly
+### External Integration Modes
+
+#### CLI / npx
 
 ```bash
-# Count tokens in all markdown files
-npm run tokens -- count
-
-# Count tokens in specific files
-npm run tokens -- count SKILL.md references/*.md
-
-# Check files against token limits
-npm run tokens -- check
-
-# Check with strict mode (exits 1 if limits exceeded)
-npm run tokens -- check --strict
-
-# Get optimization suggestions
-npm run tokens -- suggest
-
-# Score a skill directory (advisory checks)
-npm run tokens -- score .
-
-# Compare with previous commit
-npm run tokens -- compare HEAD~1
+npx @spboyer/sensei score .
+npx @spboyer/sensei check --root . --config .token-limits.json --strict
 ```
 
----
+`--root` resolves paths and discovers `.token-limits.json`; `--config` points at a specific limits file.
 
-## Library Usage
+#### GitHub Action
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+  - uses: spboyer/sensei@v1
+    with:
+      command: check
+      root: .
+      path: .
+      config: .token-limits.json
+      strict: 'true'
+```
+
+#### Library API
 
 ```ts
 import { scoreSkillContent } from '@spboyer/sensei/score';
+import { parseFrontmatter } from '@spboyer/sensei/parse';
+import { checkNameCompliance } from '@spboyer/sensei/checks';
 
 const result = scoreSkillContent(renderedSkillMarkdown, { path: 'skills/my-skill', moduleCount: 2 });
+const frontmatter = parseFrontmatter(renderedSkillMarkdown);
+checkNameCompliance(frontmatter?.name ?? '');
 ```
 
 `path` is metadata; `moduleCount` defaults to `0`.
+
+---
 
 ### GEPA Commands
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,88 @@
+name: Sensei
+description: Validate and score Agent Skills with Sensei.
+
+inputs:
+  command:
+    description: Sensei command to run: check, count, suggest, or score.
+    required: false
+    default: check
+  path:
+    description: File, directory, or skill path to pass to the command.
+    required: false
+    default: .
+  root:
+    description: Project root for path resolution and default config discovery.
+    required: false
+    default: .
+  config:
+    description: Optional token limits JSON file.
+    required: false
+    default: ''
+  strict:
+    description: Fail check when any file exceeds its limit.
+    required: false
+    default: 'true'
+  format:
+    description: Output format, usually table or json.
+    required: false
+    default: table
+  node-version:
+    description: Node.js version to use.
+    required: false
+    default: '20'
+  package-version:
+    description: npm package version or dist-tag to run.
+    required: false
+    default: latest
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Run Sensei
+      shell: bash
+      env:
+        SENSEI_COMMAND: ${{ inputs.command }}
+        SENSEI_PATH: ${{ inputs.path }}
+        SENSEI_ROOT: ${{ inputs.root }}
+        SENSEI_CONFIG: ${{ inputs.config }}
+        SENSEI_STRICT: ${{ inputs.strict }}
+        SENSEI_FORMAT: ${{ inputs.format }}
+        SENSEI_PACKAGE_VERSION: ${{ inputs.package-version }}
+      run: |
+        set -euo pipefail
+
+        case "$SENSEI_COMMAND" in
+          check|count|suggest|score) ;;
+          *)
+            echo "Unsupported Sensei command: $SENSEI_COMMAND" >&2
+            exit 1
+            ;;
+        esac
+
+        args=("$SENSEI_COMMAND")
+
+        if [[ -n "$SENSEI_ROOT" ]]; then
+          args+=("--root" "$SENSEI_ROOT")
+        fi
+
+        if [[ -n "$SENSEI_CONFIG" ]]; then
+          args+=("--config" "$SENSEI_CONFIG")
+        fi
+
+        if [[ -n "$SENSEI_FORMAT" ]]; then
+          args+=("--format=$SENSEI_FORMAT")
+        fi
+
+        if [[ "$SENSEI_COMMAND" == "check" && "$SENSEI_STRICT" == "true" ]]; then
+          args+=("--strict")
+        fi
+
+        if [[ -n "$SENSEI_PATH" ]]; then
+          args+=("$SENSEI_PATH")
+        fi
+
+        npx --yes "@spboyer/sensei@$SENSEI_PACKAGE_VERSION" "${args[@]}"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "prepack": "npm run build",
     "prepublishOnly": "npm run build && npm test"
   },
+  "bin": {
+    "sensei": "./scripts/dist/tokens/cli.js"
+  },
   "main": "./scripts/dist/score.js",
   "types": "./scripts/dist/score.d.ts",
   "exports": {
@@ -21,15 +24,19 @@
       "types": "./scripts/dist/score.d.ts",
       "import": "./scripts/dist/score.js"
     },
+    "./parse": {
+      "types": "./scripts/dist/parse.d.ts",
+      "import": "./scripts/dist/parse.js"
+    },
+    "./checks": {
+      "types": "./scripts/dist/checks.d.ts",
+      "import": "./scripts/dist/checks.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [
-    "scripts/dist/score.js",
-    "scripts/dist/score.d.ts",
-    "scripts/dist/tokens/commands/score.js",
-    "scripts/dist/tokens/commands/score.d.ts",
-    "scripts/dist/tokens/commands/types.js",
-    "scripts/dist/tokens/commands/types.d.ts",
+    "scripts/dist/**",
+    "action.yml",
     "README.md",
     "LICENSE.txt"
   ],

--- a/scripts/src/checks.ts
+++ b/scripts/src/checks.ts
@@ -1,0 +1,18 @@
+export {
+  checkAllowedFields,
+  checkCompatibilityCompliance,
+  checkCrossModelDensity,
+  checkDescriptionCompliance,
+  checkDirectoryNameMatch,
+  checkFrontmatterStructure,
+  checkLicenseRecommendation,
+  checkModuleCount,
+  checkNameCompliance,
+  checkNegativeDeltaRisk,
+  checkOverSpecificity,
+  checkProceduralContent,
+  checkVersionRecommendation,
+  classifyComplexity
+} from './tokens/commands/score.js';
+
+export type { AdvisoryCheck } from './tokens/commands/score.js';

--- a/scripts/src/package-metadata.test.ts
+++ b/scripts/src/package-metadata.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+interface PackageJson {
+  readonly bin?: Record<string, string>;
+  readonly exports?: Record<string, unknown>;
+  readonly files?: string[];
+}
+
+describe('package integration metadata', () => {
+  const pkg = JSON.parse(readFileSync('../package.json', 'utf-8')) as PackageJson;
+
+  it('publishes an npx-compatible CLI binary', () => {
+    expect(pkg.bin).toEqual({
+      sensei: './scripts/dist/tokens/cli.js'
+    });
+  });
+
+  it('publishes granular public export paths', () => {
+    expect(pkg.exports).toHaveProperty('./score');
+    expect(pkg.exports).toHaveProperty('./parse');
+    expect(pkg.exports).toHaveProperty('./checks');
+  });
+
+  it('includes compiled dist and action metadata in the npm package', () => {
+    expect(pkg.files).toContain('scripts/dist/**');
+    expect(pkg.files).toContain('action.yml');
+  });
+});

--- a/scripts/src/parse.ts
+++ b/scripts/src/parse.ts
@@ -1,0 +1,2 @@
+export { parseFrontmatter } from './tokens/commands/score.js';
+export type { ParsedFrontmatter } from './tokens/commands/score.js';

--- a/scripts/src/public-exports.test.ts
+++ b/scripts/src/public-exports.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { parseFrontmatter } from './parse.js';
+import { checkNameCompliance } from './checks.js';
+import { scoreSkillContent } from './score.js';
+
+describe('public export modules', () => {
+  const content = `---
+name: sample-skill
+description: "Analyze sample skills. WHEN: \\"sample skill\\", \\"skill check\\"."
+---
+
+# Sample Skill
+`;
+
+  it('exports parsing helpers from @spboyer/sensei/parse', () => {
+    expect(parseFrontmatter(content)?.name).toBe('sample-skill');
+  });
+
+  it('exports check helpers from @spboyer/sensei/checks', () => {
+    expect(checkNameCompliance('sample-skill').status).toBe('ok');
+  });
+
+  it('exports scoring helpers from @spboyer/sensei/score', () => {
+    expect(scoreSkillContent(content).skillPath).toBe('<memory>');
+  });
+});

--- a/scripts/src/tokens/cli.integration.test.ts
+++ b/scripts/src/tokens/cli.integration.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync, spawnSync } from 'node:child_process';
+
+function runCli(args: string[], cwd: string): string {
+  return execFileSync(process.execPath, ['--import', 'tsx', 'src/tokens/cli.ts', ...args], {
+    cwd,
+    encoding: 'utf-8'
+  });
+}
+
+function spawnCli(args: string[], cwd: string): ReturnType<typeof spawnSync> {
+  return spawnSync(process.execPath, ['--import', 'tsx', 'src/tokens/cli.ts', ...args], {
+    cwd,
+    encoding: 'utf-8'
+  });
+}
+
+describe('Sensei CLI integration', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'sensei-cli-'));
+    writeFileSync(join(tempDir, 'SKILL.md'), `---
+name: external-skill
+description: "Analyze external skills. WHEN: \\"external skill\\", \\"skill validation\\", \\"sensei check\\"."
+---
+
+# External Skill
+
+Analyze external skills.
+`);
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('scores a skill from --root when invoked outside the skill directory', () => {
+    const output = runCli(['score', '--root', tempDir, '--format=json'], process.cwd());
+    const result = JSON.parse(output);
+
+    expect(result.skillPath).toBe(tempDir);
+    expect(result.specChecks.some((check: { name: string; status: string }) =>
+      check.name === 'spec-name' && check.status === 'ok'
+    )).toBe(true);
+  });
+
+  it('checks files with an explicit config relative to --root', () => {
+    writeFileSync(join(tempDir, 'limits.json'), JSON.stringify({
+      defaults: { 'SKILL.md': 1000, '*.md': 1000 },
+      overrides: {}
+    }));
+
+    const output = runCli(['check', '--root', tempDir, '--config', 'limits.json', '--format=json', 'SKILL.md'], process.cwd());
+    const result = JSON.parse(output);
+
+    expect(result.exceededCount).toBe(0);
+    expect(result.results).toEqual([
+      expect.objectContaining({ file: 'SKILL.md', limit: 1000, exceeded: false })
+    ]);
+  });
+
+  it('returns non-zero for strict check failures using --root and --config', () => {
+    writeFileSync(join(tempDir, 'limits.json'), JSON.stringify({
+      defaults: { 'SKILL.md': 1, '*.md': 1 },
+      overrides: {}
+    }));
+
+    const result = spawnCli(['check', '--root', tempDir, '--config', 'limits.json', '--strict', 'SKILL.md'], process.cwd());
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('EXCEEDED');
+  });
+
+  it('rejects positional paths outside --root', () => {
+    const result = spawnCli(['check', '--root', tempDir, '../outside.md'], process.cwd());
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('outside the configured root');
+  });
+});

--- a/scripts/src/tokens/cli.test.ts
+++ b/scripts/src/tokens/cli.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { parseArgs } from './cli.js';
+
+describe('parseArgs', () => {
+  it('parses root and config options in equals form', () => {
+    const parsed = parseArgs([
+      'check',
+      '--root=fixtures/project',
+      '--config=.sensei-limits.json',
+      '--strict',
+      'skills/example'
+    ]);
+
+    expect(parsed.command).toBe('check');
+    expect(parsed.paths).toEqual(['skills/example']);
+    expect(parsed.options).toMatchObject({
+      root: 'fixtures/project',
+      config: '.sensei-limits.json',
+      strict: true
+    });
+  });
+
+  it('parses root and config options in space-separated form', () => {
+    const parsed = parseArgs([
+      'score',
+      '--root',
+      'fixtures/project',
+      '--config',
+      'limits.json'
+    ]);
+
+    expect(parsed.command).toBe('score');
+    expect(parsed.paths).toEqual([]);
+    expect(parsed.options).toMatchObject({
+      root: 'fixtures/project',
+      config: 'limits.json'
+    });
+  });
+
+  it('rejects missing option values', () => {
+    expect(() => parseArgs(['check', '--root'])).toThrow('Missing value for --root');
+    expect(() => parseArgs(['check', '--config', '--strict'])).toThrow('Missing value for --config');
+  });
+});

--- a/scripts/src/tokens/cli.test.ts
+++ b/scripts/src/tokens/cli.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { parseArgs } from './cli.js';
+import { describe, expect, it, vi } from 'vitest';
+import { main, parseArgs } from './cli.js';
 
 describe('parseArgs', () => {
   it('parses root and config options in equals form', () => {
@@ -40,5 +40,24 @@ describe('parseArgs', () => {
   it('rejects missing option values', () => {
     expect(() => parseArgs(['check', '--root'])).toThrow('Missing value for --root');
     expect(() => parseArgs(['check', '--config', '--strict'])).toThrow('Missing value for --config');
+  });
+});
+
+describe('main help', () => {
+  it('prints published CLI usage for external consumers', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    let help = '';
+
+    try {
+      main(['--help']);
+      help = log.mock.calls.map(([message]) => String(message)).join('\n');
+    } finally {
+      log.mockRestore();
+    }
+
+    expect(help).toContain('sensei <command> [options] [paths...]');
+    expect(help).toContain('npx @spboyer/sensei <command> [options] [paths...]');
+    expect(help).toContain('sensei count SKILL.md');
+    expect(help).not.toContain('npm run tokens');
   });
 });

--- a/scripts/src/tokens/cli.ts
+++ b/scripts/src/tokens/cli.ts
@@ -2,15 +2,15 @@
 
 /**
  * Sensei Token Management CLI
- * 
+ *
  * Usage:
- *   npm run tokens count [paths...]     Count tokens in markdown files
- *   npm run tokens check [paths...]     Check files against token limits
- *   npm run tokens suggest [paths...]   Get optimization suggestions
- *   npm run tokens compare [refs...]    Compare tokens between git refs
+ *   sensei count [paths...]     Count tokens in markdown files
+ *   sensei check [paths...]     Check files against token limits
+ *   sensei suggest [paths...]   Get optimization suggestions
+ *   sensei compare [refs...]    Compare tokens between git refs
  */
 
-import { existsSync, statSync } from 'node:fs';
+import { existsSync, realpathSync, statSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { count, check, suggest, compare, scoreSkill } from './commands/index.js';
@@ -22,7 +22,8 @@ function printHelp(): void {
 Sensei Token Management CLI
 
 Usage:
-  npm run tokens <command> [options] [paths...]
+  sensei <command> [options] [paths...]
+  npx @spboyer/sensei <command> [options] [paths...]
 
 Commands:
   count [paths...]     Count tokens in markdown files
@@ -46,13 +47,13 @@ Options:
   --help, -h           Show this help message
 
 Examples:
-  npm run tokens count                    Count all markdown files
-  npm run tokens count SKILL.md           Count specific file
-  npm run tokens count --format=json      Output as JSON
-  npm run tokens check --strict           Fail if limits exceeded
-  npm run tokens suggest                  Get optimization tips
-  npm run tokens compare HEAD~3           Compare with 3 commits ago
-  npm run tokens compare main feature     Compare two branches
+  sensei count                    Count all markdown files
+  sensei count SKILL.md           Count specific file
+  sensei count --format=json      Output as JSON
+  sensei check --strict           Fail if limits exceeded
+  sensei suggest                  Get optimization tips
+  sensei compare HEAD~3           Compare with 3 commits ago
+  sensei compare main feature     Compare two branches
 
 Configuration:
   Create .token-limits.json in project root to customize limits:
@@ -70,13 +71,13 @@ Configuration:
 }
 
 export function parseArgs(args: string[]): { command: string; paths: string[]; options: Record<string, unknown> } {
-  const command = args[0] ?? 'help';
+  const command = args[0] === '--help' || args[0] === '-h' ? 'help' : args[0] ?? 'help';
   const paths: string[] = [];
   const options: Record<string, unknown> = {};
-  
+
   for (let i = 1; i < args.length; i++) {
     const arg = args[i];
-    
+
     if (arg === '--help' || arg === '-h') {
       options.help = true;
     } else if (arg === '--strict') {
@@ -112,7 +113,7 @@ export function parseArgs(args: string[]): { command: string; paths: string[]; o
       process.exit(1);
     }
   }
-  
+
   return { command, paths, options };
 }
 
@@ -126,29 +127,29 @@ function readOptionValue(args: string[], index: number, optionName: string): str
 
 export function main(args = process.argv.slice(2)): void {
   const { command, paths, options } = parseArgs(args);
-  
+
   if (options.help || command === 'help') {
     printHelp();
     return;
   }
-  
+
   switch (command) {
     case 'count':
       count(paths, options);
       break;
-    
+
     case 'check':
       check(paths, options);
       break;
-    
+
     case 'suggest':
       suggest(paths, options);
       break;
-    
+
     case 'compare':
       compare(paths, options);
       break;
-    
+
     case 'score': {
       const rootDir = resolveRootDir(typeof options.root === 'string' ? options.root : undefined);
       const skillDir = paths[0] ? resolvePathFromRoot(rootDir, paths[0]) : rootDir;
@@ -192,15 +193,22 @@ export function main(args = process.argv.slice(2)): void {
       }
       break;
     }
-    
+
     default:
       console.error(`Unknown command: ${command}`);
-      console.error('Run "npm run tokens help" for usage information.');
+      console.error('Run "sensei help" for usage information.');
       process.exit(1);
   }
 }
 
-if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+function isEntrypoint(): boolean {
+  if (!process.argv[1]) {
+    return false;
+  }
+  return realpathSync.native(fileURLToPath(import.meta.url)) === realpathSync.native(resolve(process.argv[1]));
+}
+
+if (isEntrypoint()) {
   try {
     main();
   } catch (error) {

--- a/scripts/src/tokens/cli.ts
+++ b/scripts/src/tokens/cli.ts
@@ -11,8 +11,11 @@
  */
 
 import { existsSync, statSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { count, check, suggest, compare, scoreSkill } from './commands/index.js';
+import { getErrorMessage } from './commands/types.js';
+import { resolvePathFromRoot, resolveRootDir } from './commands/utils.js';
 
 function printHelp(): void {
   console.log(`
@@ -35,6 +38,8 @@ Options:
   --no-total           Hide total row (count only)
   --strict             Exit with error if limits exceeded (check only)
   --quiet              Suppress output except errors (check only)
+  --root=<path>        Resolve paths and default config from this project root
+  --config=<path>      Use a specific token limits JSON file
   --min-savings=<n>    Minimum savings to suggest (default: 10)
   --verbose            Show detailed suggestions
   --show-unchanged     Include unchanged files in comparison
@@ -64,7 +69,7 @@ Configuration:
 `);
 }
 
-function parseArgs(args: string[]): { command: string; paths: string[]; options: Record<string, unknown> } {
+export function parseArgs(args: string[]): { command: string; paths: string[]; options: Record<string, unknown> } {
   const command = args[0] ?? 'help';
   const paths: string[] = [];
   const options: Record<string, unknown> = {};
@@ -92,6 +97,14 @@ function parseArgs(args: string[]): { command: string; paths: string[]; options:
       options.minTokens = parseInt(arg.slice(13), 10);
     } else if (arg.startsWith('--min-savings=')) {
       options.minSavings = parseInt(arg.slice(14), 10);
+    } else if (arg === '--root') {
+      options.root = readOptionValue(args, ++i, '--root');
+    } else if (arg.startsWith('--root=')) {
+      options.root = arg.slice(7);
+    } else if (arg === '--config') {
+      options.config = readOptionValue(args, ++i, '--config');
+    } else if (arg.startsWith('--config=')) {
+      options.config = arg.slice(9);
     } else if (!arg.startsWith('-')) {
       paths.push(arg);
     } else {
@@ -103,8 +116,15 @@ function parseArgs(args: string[]): { command: string; paths: string[]; options:
   return { command, paths, options };
 }
 
-function main(): void {
-  const args = process.argv.slice(2);
+function readOptionValue(args: string[], index: number, optionName: string): string {
+  const value = args[index];
+  if (!value || value.startsWith('-')) {
+    throw new Error(`Missing value for ${optionName}`);
+  }
+  return value;
+}
+
+export function main(args = process.argv.slice(2)): void {
   const { command, paths, options } = parseArgs(args);
   
   if (options.help || command === 'help') {
@@ -130,7 +150,8 @@ function main(): void {
       break;
     
     case 'score': {
-      const skillDir = paths[0] ?? process.cwd();
+      const rootDir = resolveRootDir(typeof options.root === 'string' ? options.root : undefined);
+      const skillDir = paths[0] ? resolvePathFromRoot(rootDir, paths[0]) : rootDir;
       if (!existsSync(skillDir) || !statSync(skillDir).isDirectory()) {
         console.error(`Error: Path does not exist or is not a directory: ${skillDir}`);
         process.exit(1);
@@ -179,4 +200,11 @@ function main(): void {
   }
 }
 
-main();
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`Error: ${getErrorMessage(error)}`);
+    process.exit(1);
+  }
+}

--- a/scripts/src/tokens/commands/check.ts
+++ b/scripts/src/tokens/commands/check.ts
@@ -3,17 +3,18 @@
  */
 
 import { readFileSync, existsSync, statSync } from 'node:fs';
-import { relative, resolve } from 'node:path';
-import { loadConfig, getLimitForFile, findMarkdownFiles } from './utils.js';
+import { relative } from 'node:path';
+import { loadConfig, getLimitForFile, findMarkdownFiles, resolvePathFromRoot, resolveRootDir } from './utils.js';
 import {
   estimateTokens,
   normalizePath,
   getErrorMessage,
   type ValidationResult,
-  type ValidationReport
+  type ValidationReport,
+  type RootConfigOptions
 } from './types.js';
 
-interface CheckOptions {
+interface CheckOptions extends RootConfigOptions {
   readonly format?: 'json' | 'table';
   readonly strict?: boolean;
   readonly quiet?: boolean;
@@ -110,8 +111,8 @@ function outputJson(results: ValidationResult[]): void {
  */
 export function check(paths: string[], options: CheckOptions = {}): void {
   const opts = { ...DEFAULT_OPTIONS, ...options };
-  const rootDir = process.cwd();
-  const config = loadConfig(rootDir);
+  const rootDir = resolveRootDir(opts.root);
+  const config = loadConfig(rootDir, opts.config);
   
   let filesToProcess: string[] = [];
   
@@ -119,7 +120,7 @@ export function check(paths: string[], options: CheckOptions = {}): void {
     filesToProcess = findMarkdownFiles(rootDir);
   } else {
     for (const p of paths) {
-      const fullPath = resolve(rootDir, p);
+      const fullPath = resolvePathFromRoot(rootDir, p);
       
       if (!existsSync(fullPath)) {
         console.error(`⚠️  Path not found: ${p}`);

--- a/scripts/src/tokens/commands/count.ts
+++ b/scripts/src/tokens/commands/count.ts
@@ -3,16 +3,17 @@
  */
 
 import { readFileSync, existsSync, statSync } from 'node:fs';
-import { relative, resolve } from 'node:path';
-import { findMarkdownFiles } from './utils.js';
+import { relative } from 'node:path';
+import { findMarkdownFiles, resolvePathFromRoot, resolveRootDir } from './utils.js';
 import {
   estimateTokens,
   normalizePath,
   getErrorMessage,
-  type TokenMetadata
+  type TokenMetadata,
+  type RootConfigOptions
 } from './types.js';
 
-interface CountOptions {
+interface CountOptions extends RootConfigOptions {
   readonly format?: 'json' | 'table';
   readonly sort?: 'tokens' | 'name' | 'path';
   readonly minTokens?: number;
@@ -133,7 +134,7 @@ function outputJson(results: FileResult[], rootDir: string): void {
  */
 export function count(paths: string[], options: CountOptions = {}): void {
   const opts = { ...DEFAULT_OPTIONS, ...options };
-  const rootDir = process.cwd();
+  const rootDir = resolveRootDir(opts.root);
   
   let filesToProcess: string[] = [];
   
@@ -143,7 +144,7 @@ export function count(paths: string[], options: CountOptions = {}): void {
   } else {
     // Process specified paths
     for (const p of paths) {
-      const fullPath = resolve(rootDir, p);
+      const fullPath = resolvePathFromRoot(rootDir, p);
       
       if (!existsSync(fullPath)) {
         console.error(`⚠️  Path not found: ${p}`);

--- a/scripts/src/tokens/commands/score.ts
+++ b/scripts/src/tokens/commands/score.ts
@@ -71,7 +71,7 @@ export interface AdvisoryCheck {
 // ---------------------------------------------------------------------------
 
 /** Parsed frontmatter fields */
-interface ParsedFrontmatter {
+export interface ParsedFrontmatter {
   readonly fields: Record<string, unknown>;
   readonly name?: string;
   readonly description?: string;

--- a/scripts/src/tokens/commands/suggest.ts
+++ b/scripts/src/tokens/commands/suggest.ts
@@ -3,8 +3,8 @@
  */
 
 import { readFileSync, existsSync, statSync } from 'node:fs';
-import { relative, resolve } from 'node:path';
-import { loadConfig, getLimitForFile, findMarkdownFiles } from './utils.js';
+import { relative } from 'node:path';
+import { loadConfig, getLimitForFile, findMarkdownFiles, resolvePathFromRoot, resolveRootDir } from './utils.js';
 import {
   estimateTokens,
   normalizePath,
@@ -16,10 +16,11 @@ import {
   TOKENS_PER_CODE_LINE,
   TOKENS_PER_TABLE_ROW,
   type Suggestion,
-  type FileAnalysis
+  type FileAnalysis,
+  type RootConfigOptions
 } from './types.js';
 
-interface SuggestOptions {
+interface SuggestOptions extends RootConfigOptions {
   readonly format?: 'json' | 'text';
   readonly minSavings?: number;
   readonly verbose?: boolean;
@@ -221,8 +222,8 @@ function outputJson(analyses: FileAnalysis[]): void {
  */
 export function suggest(paths: string[], options: SuggestOptions = {}): void {
   const opts = { ...DEFAULT_OPTIONS, ...options };
-  const rootDir = process.cwd();
-  const config = loadConfig(rootDir);
+  const rootDir = resolveRootDir(opts.root);
+  const config = loadConfig(rootDir, opts.config);
   
   let filesToProcess: string[] = [];
   
@@ -230,7 +231,7 @@ export function suggest(paths: string[], options: SuggestOptions = {}): void {
     filesToProcess = findMarkdownFiles(rootDir);
   } else {
     for (const p of paths) {
-      const fullPath = resolve(rootDir, p);
+      const fullPath = resolvePathFromRoot(rootDir, p);
       
       if (!existsSync(fullPath)) {
         console.error(`⚠️  Path not found: ${p}`);

--- a/scripts/src/tokens/commands/types.ts
+++ b/scripts/src/tokens/commands/types.ts
@@ -99,6 +99,11 @@ export interface FileAnalysis {
   readonly potentialSavings: number;
 }
 
+export interface RootConfigOptions {
+  readonly root?: string;
+  readonly config?: string;
+}
+
 /** Characters per token approximation */
 const CHARS_PER_TOKEN = 4;
 

--- a/scripts/src/tokens/commands/utils.test.ts
+++ b/scripts/src/tokens/commands/utils.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { loadConfig, resolvePathFromRoot, resolveRootDir } from './utils.js';
+
+describe('root and config utilities', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'sensei-utils-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('resolves an explicit root directory', () => {
+    const projectDir = join(tempDir, 'project');
+    mkdirSync(projectDir);
+
+    expect(resolveRootDir(projectDir)).toBe(projectDir);
+  });
+
+  it('loads an explicit config path relative to root', () => {
+    const projectDir = join(tempDir, 'project');
+    mkdirSync(projectDir);
+    writeFileSync(join(projectDir, 'limits.json'), JSON.stringify({
+      defaults: { '*.md': 123 },
+      overrides: {}
+    }));
+
+    expect(loadConfig(projectDir, 'limits.json').defaults['*.md']).toBe(123);
+  });
+
+  it('throws when an explicit config path is missing', () => {
+    expect(() => loadConfig(tempDir, 'missing.json')).toThrow('Token limits config not found');
+  });
+
+  it('rejects paths outside the configured root', () => {
+    expect(() => resolvePathFromRoot(tempDir, '../outside.md')).toThrow('outside the configured root');
+  });
+});

--- a/scripts/src/tokens/commands/utils.test.ts
+++ b/scripts/src/tokens/commands/utils.test.ts
@@ -1,18 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
-import { tmpdir } from 'node:os';
 import { loadConfig, resolvePathFromRoot, resolveRootDir } from './utils.js';
 
 describe('root and config utilities', () => {
   let tempDir: string;
+  const testWorkspace = join(process.cwd(), '.test-workspace');
 
   beforeEach(() => {
-    tempDir = mkdtempSync(join(tmpdir(), 'sensei-utils-'));
+    tempDir = join(testWorkspace, `sensei-utils-${randomUUID()}`);
+    mkdirSync(tempDir, { recursive: true });
   });
 
   afterEach(() => {
-    rmSync(tempDir, { recursive: true, force: true });
+    rmSync(testWorkspace, { recursive: true, force: true });
   });
 
   it('resolves an explicit root directory', () => {
@@ -39,5 +41,16 @@ describe('root and config utilities', () => {
 
   it('rejects paths outside the configured root', () => {
     expect(() => resolvePathFromRoot(tempDir, '../outside.md')).toThrow('outside the configured root');
+  });
+
+  it('rejects symlinked paths that resolve outside the configured root', () => {
+    const projectDir = join(tempDir, 'project');
+    const outsideDir = join(tempDir, 'outside');
+    mkdirSync(projectDir);
+    mkdirSync(outsideDir);
+    writeFileSync(join(outsideDir, 'secret.md'), '# outside');
+    symlinkSync(outsideDir, join(projectDir, 'link'), process.platform === 'win32' ? 'junction' : 'dir');
+
+    expect(() => resolvePathFromRoot(projectDir, 'link/secret.md')).toThrow('outside the configured root');
   });
 });

--- a/scripts/src/tokens/commands/utils.ts
+++ b/scripts/src/tokens/commands/utils.ts
@@ -2,7 +2,7 @@
  * Shared utility functions for token commands
  */
 
-import { readFileSync, readdirSync, existsSync, statSync, Dirent } from 'node:fs';
+import { readFileSync, readdirSync, existsSync, realpathSync, statSync, Dirent } from 'node:fs';
 import { isAbsolute, join, relative, resolve, sep } from 'node:path';
 import type { TokenLimitsConfig } from './types.js';
 import {
@@ -63,12 +63,24 @@ export function resolveRootDir(root?: string): string {
   return rootDir;
 }
 
+function isOutsideRoot(rootDir: string, fullPath: string): boolean {
+  const relativePath = relative(rootDir, fullPath);
+  return relativePath === '..' || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath);
+}
+
 export function resolvePathFromRoot(rootDir: string, inputPath: string): string {
   const fullPath = isAbsolute(inputPath) ? resolve(inputPath) : resolve(rootDir, inputPath);
-  const relativePath = relative(rootDir, fullPath);
 
-  if (relativePath === '..' || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
+  if (isOutsideRoot(rootDir, fullPath)) {
     throw new Error(`Path is outside the configured root: ${inputPath}`);
+  }
+
+  if (existsSync(fullPath)) {
+    const realRootDir = realpathSync.native(rootDir);
+    const realFullPath = realpathSync.native(fullPath);
+    if (isOutsideRoot(realRootDir, realFullPath)) {
+      throw new Error(`Path is outside the configured root: ${inputPath}`);
+    }
   }
 
   return fullPath;

--- a/scripts/src/tokens/commands/utils.ts
+++ b/scripts/src/tokens/commands/utils.ts
@@ -2,8 +2,8 @@
  * Shared utility functions for token commands
  */
 
-import { readFileSync, readdirSync, existsSync, Dirent } from 'node:fs';
-import { join } from 'node:path';
+import { readFileSync, readdirSync, existsSync, statSync, Dirent } from 'node:fs';
+import { isAbsolute, join, relative, resolve, sep } from 'node:path';
 import type { TokenLimitsConfig } from './types.js';
 import {
   DEFAULT_LIMITS,
@@ -17,9 +17,11 @@ import {
 /**
  * Loads token limits configuration from .token-limits.json or returns defaults.
  */
-export function loadConfig(rootDir: string): TokenLimitsConfig {
-  const configPath = join(rootDir, '.token-limits.json');
-  
+export function loadConfig(rootDir: string, explicitConfigPath?: string): TokenLimitsConfig {
+  const configPath = explicitConfigPath
+    ? resolveConfigPath(rootDir, explicitConfigPath)
+    : join(rootDir, '.token-limits.json');
+
   if (existsSync(configPath)) {
     try {
       const content = readFileSync(configPath, 'utf-8');
@@ -31,14 +33,46 @@ export function loadConfig(rootDir: string): TokenLimitsConfig {
       
       return parsed as TokenLimitsConfig;
     } catch (error) {
+      if (explicitConfigPath) {
+        throw new Error(`Invalid token limits config at ${configPath}: ${getErrorMessage(error)}`);
+      }
       console.error(`⚠️  Warning: Invalid .token-limits.json (${getErrorMessage(error)}), using defaults`);
       return DEFAULT_LIMITS;
     }
+  }
+
+  if (explicitConfigPath) {
+    throw new Error(`Token limits config not found: ${configPath}`);
   }
   
   return DEFAULT_LIMITS;
 }
 
+function resolveConfigPath(rootDir: string, configPath: string): string {
+  return isAbsolute(configPath) ? configPath : resolve(rootDir, configPath);
+}
+
+export function resolveRootDir(root?: string): string {
+  const rootDir = resolve(process.cwd(), root ?? '.');
+  if (!existsSync(rootDir)) {
+    throw new Error(`Root path not found: ${rootDir}`);
+  }
+  if (!statSync(rootDir).isDirectory()) {
+    throw new Error(`Root path is not a directory: ${rootDir}`);
+  }
+  return rootDir;
+}
+
+export function resolvePathFromRoot(rootDir: string, inputPath: string): string {
+  const fullPath = isAbsolute(inputPath) ? resolve(inputPath) : resolve(rootDir, inputPath);
+  const relativePath = relative(rootDir, fullPath);
+
+  if (relativePath === '..' || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
+    throw new Error(`Path is outside the configured root: ${inputPath}`);
+  }
+
+  return fullPath;
+}
 /**
  * Calculates specificity score for a glob pattern.
  */


### PR DESCRIPTION
Sensei's scoring and validation logic is useful outside this repository, but consumers needed to clone the repo or import internal implementation paths. This adds first-class integration surfaces for CLI, GitHub Action, and library usage so other skill projects can run Sensei directly.

## What changed

- Adds an npm `sensei` binary for `npx` / `npm exec` usage.
- Adds `--root` and `--config` handling so `check`, `count`, `suggest`, and `score` can run against external project roots.
- Adds granular public exports for `@spboyer/sensei/score`, `@spboyer/sensei/parse`, and `@spboyer/sensei/checks`.
- Adds a reusable composite `action.yml` for GitHub Action consumers.
- Broadens package contents to include compiled dist dependencies and action metadata.
- Expands tests with CLI integration coverage, package metadata checks, public export coverage, and packed consumer smoke validation.

## Notes

The intended CI/release workflow updates were not included because the current GitHub token was rejected for workflow-file updates without the `workflow` scope. Those workflow changes should be added in a follow-up with an appropriately scoped token.

Fixes: #11