### PR TITLE
Publish npm package on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,14 @@
 name: Publish to npm
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to publish, such as v1.5.0.
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -15,9 +20,14 @@ concurrency:
 
 jobs:
   publish:
+    if: startsWith(github.event.release.tag_name || inputs.tag, 'v')
     runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
 
       - uses: actions/setup-node@v4
         with:
@@ -32,12 +42,15 @@ jobs:
       - name: Verify tag matches package version
         run: |
           package_version=$(node -p "require('./package.json').version")
-          tag_version="${GITHUB_REF_NAME#v}"
+          tag_version="${RELEASE_TAG#v}"
 
           if [[ "$package_version" != "$tag_version" ]]; then
-            echo "Tag v$tag_version does not match package.json version $package_version" >&2
+            echo "Tag $RELEASE_TAG does not match package.json version $package_version" >&2
             exit 1
           fi
+
+      - name: Verify package
+        run: npm run build && npm test
 
       - name: Publish package
         run: npm publish --access public --provenance

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ npx @spboyer/sensei score .
 npx @spboyer/sensei check --root . --config .token-limits.json --strict
 ```
 
-`--root` resolves paths and discovers `.token-limits.json`; `--config` points at a specific limits file.
+`--root` resolves paths; `--config` selects limits. Global install: `npm install --global @spboyer/sensei`.
 
 #### GitHub Action
 
@@ -165,13 +165,8 @@ python scripts/src/gepa/auto_evaluator.py optimize --skill my-skill
 #### Option 1: Install as Copilot CLI Skill (Recommended)
 
 ```bash
-# Create the skills folder
 mkdir -p "$HOME/.copilot/skills"
-
-# Clone to your skills directory
 git clone https://github.com/spboyer/sensei.git "$HOME/.copilot/skills/sensei"
-
-# Install token CLI dependencies
 cd ~/.copilot/skills/sensei/scripts && npm install
 ```
 
@@ -185,22 +180,26 @@ Run sensei on my-skill-name
 For project-specific installation:
 
 ```bash
-# From your project root
 mkdir -p .github/skills
 git clone https://github.com/spboyer/sensei.git .github/skills/sensei
-
-# Install dependencies
 cd .github/skills/sensei/scripts && npm install
+```
+
+#### Option 3: Install the CLI from npm
+
+For CLI/library use:
+
+```bash
+npm install --global @spboyer/sensei
+sensei check .
+npx @spboyer/sensei check .
 ```
 
 #### Verify Installation
 
 ```bash
-# Test the token CLI
-cd ~/.copilot/skills/sensei  # or your install path
-npm run tokens -- check
-
-# Should output token counts for all markdown files
+cd ~/.copilot/skills/sensei && npm run tokens -- check
+npx @spboyer/sensei check .
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "prepublishOnly": "npm run build && npm test"
   },
   "bin": {
-    "sensei": "./scripts/dist/tokens/cli.js"
+    "sensei": "scripts/dist/tokens/cli.js"
   },
-  "main": "./scripts/dist/score.js",
-  "types": "./scripts/dist/score.d.ts",
+  "main": "scripts/dist/score.js",
+  "types": "scripts/dist/score.d.ts",
   "exports": {
     ".": {
       "types": "./scripts/dist/score.d.ts",

--- a/scripts/src/package-metadata.test.ts
+++ b/scripts/src/package-metadata.test.ts
@@ -12,7 +12,7 @@ describe('package integration metadata', () => {
 
   it('publishes an npx-compatible CLI binary', () => {
     expect(pkg.bin).toEqual({
-      sensei: './scripts/dist/tokens/cli.js'
+      sensei: 'scripts/dist/tokens/cli.js'
     });
   });
 


### PR DESCRIPTION
## Summary
- publish to npm when a GitHub Release is published, with manual dispatch for retrying an existing tag
- verify package version, build, and tests before npm publish
- document npm global install and npx usage
- normalize npm package bin metadata to avoid npm publish auto-correction

## Validation
- npm test
- npm run build
- npm pack --dry-run
- npm run tokens -- check README.md
- local tarball install smoke test for @spboyer/sensei/score and the sensei CLI

Fixes #17
Relates #14