### PR TITLE
Fix npm provenance metadata

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name || inputs.tag }}
+          ref: ${{ github.event.release.tag_name || github.ref }}
 
       - uses: actions/setup-node@v4
         with:

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.5.0",
   "description": "AI-powered frontmatter compliance skill for GitHub Copilot",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/spboyer/sensei"
+  },
   "scripts": {
     "build": "npm --prefix scripts run build",
     "tokens": "node --import ./scripts/node_modules/tsx/dist/loader.mjs scripts/src/tokens/cli.ts",


### PR DESCRIPTION
## Summary
- add package repository metadata required by npm provenance verification
- make manual publish retries use the workflow ref while still validating the requested release tag

## Validation
- npm test
- npm run build
- npm pack --dry-run
- npm run tokens -- check README.md

Follow-up to #18 for #17.