### PR TITLE
Skip npm publish for existing versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,9 @@ jobs:
         run: npm ci --prefix scripts
 
       - name: Verify tag matches package version
+        id: package
         run: |
+          package_name=$(node -p "require('./package.json').name")
           package_version=$(node -p "require('./package.json').version")
           tag_version="${RELEASE_TAG#v}"
 
@@ -49,10 +51,27 @@ jobs:
             exit 1
           fi
 
+          echo "name=$package_name" >> "$GITHUB_OUTPUT"
+          echo "version=$package_version" >> "$GITHUB_OUTPUT"
+
       - name: Verify package
         run: npm run build && npm test
 
+      - name: Check npm version
+        id: npm
+        run: |
+          package="${{ steps.package.outputs.name }}@${{ steps.package.outputs.version }}"
+
+          if npm view "$package" version >/dev/null 2>&1; then
+            echo "$package is already published; skipping npm publish."
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "$package is not published yet."
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish package
+        if: steps.npm.outputs.published == 'false'
         run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "https://github.com/spboyer/sensei"
+    "url": "git+https://github.com/spboyer/sensei.git"
   },
   "scripts": {
     "build": "npm --prefix scripts run build",


### PR DESCRIPTION
## Summary
- skip `npm publish` when the requested package version already exists on npm
- keep build/tests running before the skip so workflow dispatches still validate the package
- normalize repository metadata to npm's expected git URL form

## Validation
- npm test
- npm run build
- npm pack --dry-run
- npm run tokens -- check README.md

Follow-up to #19 for #17.