### PR TITLE
feat(canvas): add Copilot CLI canvas (Phase 1 + Phase 2)

### DIFF
--- a/.canvas/app.js
+++ b/.canvas/app.js
@@ -7,7 +7,7 @@
  * during high-frequency append events.
  */
 
-import { marked } from 'https://cdn.jsdelivr.net/npm/marked@12/lib/marked.esm.js';
+import { marked } from '/vendor/marked.esm.js';
 
 const els = {
   status: document.getElementById('status'),
@@ -42,6 +42,21 @@ function escape(s) {
     .replaceAll('&', '&amp;')
     .replaceAll('<', '&lt;')
     .replaceAll('>', '&gt;');
+}
+
+/**
+ * Lightweight sanitizer for marked-rendered HTML.
+ *
+ * The canvas runs on loopback, but report.md content is derived from
+ * agent-supplied JSON (e.g. notes, skill names). Stripping script tags,
+ * event handler attributes, and javascript: URLs prevents accidental or
+ * malicious injection from reaching the canvas iframe.
+ */
+function sanitizeHtml(html) {
+  return html
+    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+    .replace(/\s+on\w+\s*=/gi, ' data-removed=')
+    .replace(/href\s*=\s*["']?javascript:/gi, 'href="javascript-removed:');
 }
 
 function renderStep(step, idx) {
@@ -80,7 +95,7 @@ async function loadReport(runId) {
     const res = await fetch(withToken('/report'));
     if (!res.ok) return;
     const md = await res.text();
-    els.reportMd.innerHTML = marked.parse(md);
+    els.reportMd.innerHTML = sanitizeHtml(marked.parse(md));
   } catch (err) {
     els.reportMd.textContent = String(err);
   }

--- a/.canvas/app.js
+++ b/.canvas/app.js
@@ -61,11 +61,23 @@ function renderStep(step, idx) {
   return li;
 }
 
+/**
+ * Loopback token plumbed from the page URL (the provider hands the
+ * iframe a URL like `http://127.0.0.1:PORT/?t=...`). Every fetch and
+ * the SSE EventSource forward this on the query string so the provider
+ * can validate them.
+ */
+const TOKEN = new URLSearchParams(window.location.search).get('t') ?? '';
+function withToken(path) {
+  const sep = path.includes('?') ? '&' : '?';
+  return TOKEN ? `${path}${sep}t=${encodeURIComponent(TOKEN)}` : path;
+}
+
 async function loadReport(runId) {
   if (runId === lastReportRunId) return;
   lastReportRunId = runId;
   try {
-    const res = await fetch('/report');
+    const res = await fetch(withToken('/report'));
     if (!res.ok) return;
     const md = await res.text();
     els.reportMd.innerHTML = marked.parse(md);
@@ -103,7 +115,7 @@ function apply(state) {
   if (state.runId) loadReport(state.runId);
 }
 
-const es = new EventSource('/events');
+const es = new EventSource(withToken('/events'));
 es.onmessage = (e) => {
   try {
     apply(JSON.parse(e.data));

--- a/.canvas/app.js
+++ b/.canvas/app.js
@@ -1,0 +1,117 @@
+/**
+ * Sensei canvas iframe app.
+ *
+ * Subscribes to /events (SSE) and re-renders one of three views (idle,
+ * running, report) per the broadcast state. Uses `marked` for the final
+ * markdown report; the running view is plain DOM so it stays snappy
+ * during high-frequency append events.
+ */
+
+import { marked } from 'https://cdn.jsdelivr.net/npm/marked@12/lib/marked.esm.js';
+
+const els = {
+  status: document.getElementById('status'),
+  views: {
+    idle: document.getElementById('view-idle'),
+    running: document.getElementById('view-running'),
+    complete: document.getElementById('view-report'),
+  },
+  runningRunId: document.getElementById('running-run-id'),
+  reportRunId: document.getElementById('report-run-id'),
+  stepsList: document.getElementById('steps-list'),
+  reportMd: document.getElementById('report-md'),
+};
+
+let lastReportRunId = null;
+let lastStepCount = 0;
+
+function setStatus(phase) {
+  const label = phase === 'running' ? 'Running' : phase === 'complete' ? 'Complete' : 'Idle';
+  els.status.textContent = label;
+  els.status.className = `status status--${phase}`;
+}
+
+function show(view) {
+  for (const [name, el] of Object.entries(els.views)) {
+    el.hidden = name !== view;
+  }
+}
+
+function escape(s) {
+  return String(s)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
+function renderStep(step, idx) {
+  const li = document.createElement('li');
+  li.className = 'step';
+  const time = step.t ? new Date(step.t).toLocaleTimeString() : '';
+  const tag = step.step ?? step.phase ?? '·';
+  const skill = step.skill ? ` [${step.skill}]` : '';
+  const msg = step.message ?? step.lastAction ?? '';
+  const score = step.score != null ? ` (score: ${step.score})` : '';
+  li.innerHTML = `
+    <span class="step-time">${escape(time)}</span>
+    <span class="step-tag">${escape(tag)}</span>
+    <span class="step-text">${escape(skill + (msg ? ' ' + msg : '') + score)}</span>
+  `;
+  li.dataset.idx = String(idx);
+  return li;
+}
+
+async function loadReport(runId) {
+  if (runId === lastReportRunId) return;
+  lastReportRunId = runId;
+  try {
+    const res = await fetch('/report');
+    if (!res.ok) return;
+    const md = await res.text();
+    els.reportMd.innerHTML = marked.parse(md);
+  } catch (err) {
+    els.reportMd.textContent = String(err);
+  }
+}
+
+function apply(state) {
+  setStatus(state.phase);
+
+  if (state.phase === 'idle') {
+    show('idle');
+    lastStepCount = 0;
+    lastReportRunId = null;
+    return;
+  }
+
+  if (state.phase === 'running') {
+    show('running');
+    els.runningRunId.textContent = state.runId ?? '';
+    if (state.steps.length < lastStepCount) {
+      els.stepsList.innerHTML = '';
+      lastStepCount = 0;
+    }
+    for (let i = lastStepCount; i < state.steps.length; i++) {
+      els.stepsList.appendChild(renderStep(state.steps[i], i));
+    }
+    lastStepCount = state.steps.length;
+    return;
+  }
+
+  show('complete');
+  els.reportRunId.textContent = state.runId ?? '';
+  if (state.runId) loadReport(state.runId);
+}
+
+const es = new EventSource('/events');
+es.onmessage = (e) => {
+  try {
+    apply(JSON.parse(e.data));
+  } catch (err) {
+    console.error('bad event payload', err);
+  }
+};
+es.onerror = () => {
+  els.status.textContent = 'Disconnected';
+  els.status.className = 'status status--idle';
+};

--- a/.canvas/extension.mjs
+++ b/.canvas/extension.mjs
@@ -1,0 +1,318 @@
+/**
+ * Sensei canvas provider.
+ *
+ * Watches the sensei artifact directory for run progress (steps.ndjson)
+ * and final reports (report.md), and serves an iframe view over a local
+ * loopback HTTP server. The Copilot CLI runtime spawns this process when
+ * a session asks to open the `sensei` canvas.
+ *
+ * Architecture:
+ *   - HTTP server on 127.0.0.1:0 (OS-assigned port). Serves static assets
+ *     plus three JSON/SSE endpoints (/state, /events, /report).
+ *   - File watcher on the artifacts dir:
+ *       runs/latest.txt        → tells us which run to tail
+ *       runs/<id>/steps.ndjson → per-step append-only stream
+ *       runs/<id>/report.md    → final report (when present)
+ *   - SSE broadcasts the in-memory `state` object to all connected
+ *     iframes on every change.
+ *
+ * Pending SDK integration:
+ *   When @github/copilot-sdk/extension ships, the bottom of this file
+ *   should call:
+ *     await joinSession({ canvases: [createCanvas({ id: "sensei", ... })] });
+ *   and the canvas's open() handler will return the base URL +
+ *   per-instance loopback token. Until then, this file runs standalone
+ *   so we can iterate on the iframe and watcher logic. See the README
+ *   for the integration TODO.
+ *
+ * Cross-package note:
+ *   `encodeExtensionId` here MUST match the CLI's helper in
+ *   `scripts/src/tokens/commands/artifacts.ts`. The mapping is pinned by
+ *   a unit test there.
+ */
+
+import http from 'node:http';
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { watch, createReadStream, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { homedir } from 'node:os';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ---------------------------------------------------------------------------
+// Path resolution (mirror of scripts/src/tokens/commands/artifacts.ts)
+// ---------------------------------------------------------------------------
+
+const SENSEI_EXTENSION_ID = 'skill:github.com/spboyer/sensei:sensei';
+
+function encodeExtensionId(id) {
+  return id.replace(/:/g, '__').replace(/\//g, '_').toLowerCase();
+}
+
+function resolveCopilotHome() {
+  return process.env.COPILOT_HOME ?? join(homedir(), '.copilot');
+}
+
+function resolveArtifactsDir() {
+  if (process.env.COPILOT_EXTENSION_ARTIFACTS_DIR) {
+    return process.env.COPILOT_EXTENSION_ARTIFACTS_DIR;
+  }
+  return join(
+    resolveCopilotHome(),
+    'extensions',
+    encodeExtensionId(SENSEI_EXTENSION_ID),
+    'artifacts'
+  );
+}
+
+const ARTIFACTS_DIR = resolveArtifactsDir();
+const RUNS_DIR = join(ARTIFACTS_DIR, 'runs');
+const LATEST_PATH = join(RUNS_DIR, 'latest.txt');
+
+// ---------------------------------------------------------------------------
+// In-memory state + SSE subscribers
+// ---------------------------------------------------------------------------
+
+/**
+ * Shape we broadcast to the iframe.
+ *
+ *   phase:
+ *     "idle"     — no runs/latest.txt or it points at nothing renderable
+ *     "running"  — the active run has steps.ndjson but no report.md yet
+ *     "complete" — the active run has report.md
+ */
+const state = {
+  phase: 'idle',
+  runId: null,
+  steps: [],
+  hasReport: false,
+  artifactsDir: ARTIFACTS_DIR,
+};
+
+/** Per-file offset bookkeeping so we don't re-broadcast already-seen lines. */
+const tailOffsets = new Map();
+
+/** Connected SSE clients. */
+const subscribers = new Set();
+
+function broadcast() {
+  if (subscribers.size === 0) return;
+  const payload = `data: ${JSON.stringify(state)}\n\n`;
+  for (const res of subscribers) {
+    try {
+      res.write(payload);
+    } catch {
+      /* client dropped; cleanup happens on req 'close' */
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// File ingestion
+// ---------------------------------------------------------------------------
+
+/**
+ * Read newly appended bytes from an NDJSON file and push parsed objects
+ * into state.steps. Tolerates partial-line writes by leaving the trailing
+ * non-newline-terminated fragment in the offset (we re-read it next time).
+ */
+async function tailStepsFile(path) {
+  if (!existsSync(path)) return;
+  const { size } = await stat(path);
+  const prev = tailOffsets.get(path) ?? 0;
+  if (size <= prev) return;
+  const buf = await new Promise((resolve, reject) => {
+    const chunks = [];
+    createReadStream(path, { start: prev, end: size - 1 })
+      .on('data', (c) => chunks.push(c))
+      .on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
+      .on('error', reject);
+  });
+  const lastNl = buf.lastIndexOf('\n');
+  if (lastNl < 0) return; // no complete line yet
+  const consumed = buf.slice(0, lastNl);
+  tailOffsets.set(path, prev + Buffer.byteLength(consumed, 'utf8') + 1);
+  for (const line of consumed.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      state.steps.push(JSON.parse(trimmed));
+    } catch {
+      /* defensive: skip malformed lines from a truncated write */
+    }
+  }
+}
+
+async function readLatestRunId() {
+  if (!existsSync(LATEST_PATH)) return null;
+  try {
+    return (await readFile(LATEST_PATH, 'utf8')).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Re-sync state to whatever runs/latest.txt currently points at.
+ * Idempotent; safe to spam.
+ */
+async function syncStateFromDisk() {
+  const runId = await readLatestRunId();
+  if (!runId) {
+    state.phase = 'idle';
+    state.runId = null;
+    state.steps = [];
+    state.hasReport = false;
+    return;
+  }
+  if (runId !== state.runId) {
+    state.runId = runId;
+    state.steps = [];
+    tailOffsets.clear();
+  }
+  const runDir = join(RUNS_DIR, runId);
+  const stepsPath = join(runDir, 'steps.ndjson');
+  const reportPath = join(runDir, 'report.md');
+  await tailStepsFile(stepsPath);
+  state.hasReport = existsSync(reportPath);
+  state.phase = state.hasReport ? 'complete' : state.steps.length > 0 ? 'running' : 'idle';
+}
+
+/**
+ * Debounce: fs.watch fires multiple events per write on most platforms;
+ * coalesce them so we don't broadcast 5x for one append.
+ */
+let syncPending = null;
+function scheduleSync() {
+  if (syncPending) return;
+  syncPending = setTimeout(async () => {
+    syncPending = null;
+    try {
+      await syncStateFromDisk();
+      broadcast();
+    } catch (err) {
+      console.error('[sensei-canvas] sync error:', err);
+    }
+  }, 50);
+}
+
+/**
+ * Recursive watcher across the artifacts dir. Node 18+ `fs.watch` supports
+ * `{ recursive: true }` on macOS and Windows; Linux does not — we fall
+ * back to per-directory watchers and add child watchers as run dirs
+ * appear.
+ */
+function startWatching() {
+  if (!existsSync(RUNS_DIR)) {
+    setTimeout(startWatching, 1000);
+    return;
+  }
+  const isLinux = process.platform === 'linux';
+  if (!isLinux) {
+    watch(RUNS_DIR, { recursive: true }, scheduleSync);
+    return;
+  }
+  const childWatchers = new Map();
+  watch(RUNS_DIR, async () => {
+    scheduleSync();
+    try {
+      const entries = await readdir(RUNS_DIR, { withFileTypes: true });
+      for (const e of entries) {
+        if (e.isDirectory() && !childWatchers.has(e.name)) {
+          const w = watch(join(RUNS_DIR, e.name), scheduleSync);
+          childWatchers.set(e.name, w);
+        }
+      }
+    } catch {
+      /* directory disappeared mid-read; ignore */
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// HTTP / SSE server
+// ---------------------------------------------------------------------------
+
+const ASSETS = {
+  '/': { path: join(__dirname, 'index.html'), type: 'text/html; charset=utf-8' },
+  '/index.html': { path: join(__dirname, 'index.html'), type: 'text/html; charset=utf-8' },
+  '/app.js': { path: join(__dirname, 'app.js'), type: 'application/javascript' },
+  '/styles.css': { path: join(__dirname, 'styles.css'), type: 'text/css' },
+};
+
+async function serveAsset(req, res, asset) {
+  try {
+    const body = await readFile(asset.path);
+    res.writeHead(200, { 'Content-Type': asset.type });
+    res.end(body);
+  } catch (err) {
+    res.writeHead(500);
+    res.end(String(err));
+  }
+}
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url, 'http://127.0.0.1');
+  // TODO(sdk): once @github/copilot-sdk/extension ships, gate every
+  // request on validateLoopbackToken(req, instanceId). Today there's no
+  // token because there's no runtime issuing one.
+  const asset = ASSETS[url.pathname];
+  if (req.method === 'GET' && asset) return serveAsset(req, res, asset);
+
+  if (req.method === 'GET' && url.pathname === '/state') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(state));
+    return;
+  }
+  if (req.method === 'GET' && url.pathname === '/events') {
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    });
+    res.write(`data: ${JSON.stringify(state)}\n\n`);
+    subscribers.add(res);
+    req.on('close', () => subscribers.delete(res));
+    return;
+  }
+  if (req.method === 'GET' && url.pathname === '/report') {
+    if (!state.runId || !state.hasReport) {
+      res.writeHead(404);
+      res.end('no report yet');
+      return;
+    }
+    try {
+      const md = await readFile(join(RUNS_DIR, state.runId, 'report.md'), 'utf8');
+      res.writeHead(200, { 'Content-Type': 'text/markdown; charset=utf-8' });
+      res.end(md);
+    } catch (err) {
+      res.writeHead(500);
+      res.end(String(err));
+    }
+    return;
+  }
+
+  res.writeHead(404);
+  res.end();
+});
+
+// ---------------------------------------------------------------------------
+// Bootstrap
+// ---------------------------------------------------------------------------
+
+async function main() {
+  await syncStateFromDisk();
+  startWatching();
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address();
+  // The runtime would normally receive this URL via the SDK's open() return
+  // value. For standalone runs we log it so a developer can open it directly.
+  console.log(`[sensei-canvas] listening on http://127.0.0.1:${port}/`);
+  console.log(`[sensei-canvas] artifacts: ${ARTIFACTS_DIR}`);
+}
+
+main().catch((err) => {
+  console.error('[sensei-canvas] fatal:', err);
+  process.exit(1);
+});

--- a/.canvas/extension.mjs
+++ b/.canvas/extension.mjs
@@ -268,21 +268,24 @@ const LOOPBACK_TOKEN =
 /**
  * Stub for `validateLoopbackToken` from `@github/copilot-sdk/extension`.
  *
- * Signature is pinned to match the eventual SDK export so call sites
- * stay stable through the swap:
+ * Signature is pinned to match the SDK export (per runtime spec §11) so
+ * the call site stays stable through the SDK swap:
  *
- *     validateLoopbackToken(req: IncomingMessage, instanceId: string): boolean
+ *     validateLoopbackToken(req: IncomingMessage): boolean
  *
- * The `instanceId` parameter is reserved for the SDK's per-instance
- * token registry; this stub ignores it because we have exactly one
- * provider process and one effective instance.
+ * Runtime adopted the per-process-token design: every provider fork
+ * (including reload restarts) gets a fresh token via the env var, so the
+ * SDK doesn't need a per-instance registry and the helper takes only the
+ * request. The token MUST NOT be cached across reload boundaries — this
+ * stub reads it once at module load, which is fine because reloads kill
+ * and re-spawn the process (fresh module = fresh env-var read).
  *
  * Accepts the token from either the `t` query parameter (used by the
- * iframe so EventSource and fetch can include it) or an
- * `X-Copilot-Canvas-Token` header (useful for command-line testing).
+ * iframe so EventSource and fetch can include it without a custom
+ * header) or an `X-Copilot-Canvas-Token` header (useful for
+ * command-line testing).
  */
-// eslint-disable-next-line no-unused-vars
-function validateLoopbackToken(req, _instanceId) {
+function validateLoopbackToken(req) {
   const url = new URL(req.url, 'http://127.0.0.1');
   const fromQuery = url.searchParams.get('t');
   const fromHeader = req.headers['x-copilot-canvas-token'];
@@ -327,7 +330,7 @@ const server = http.createServer(async (req, res) => {
   // ships, the local `validateLoopbackToken` stub is replaced by the
   // SDK export — call site stays the same because the signature is
   // pinned.
-  if (!validateLoopbackToken(req, /* instanceId */ 'sensei')) {
+  if (!validateLoopbackToken(req)) {
     res.writeHead(403, { 'Content-Type': 'text/plain' });
     res.end('forbidden');
     return;

--- a/.canvas/extension.mjs
+++ b/.canvas/extension.mjs
@@ -47,7 +47,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const SENSEI_EXTENSION_ID = 'skill:github.com/spboyer/sensei:sensei';
 
 function encodeExtensionId(id) {
-  return id.replace(/:/g, '__').replace(/\//g, '_').toLowerCase();
+  return encodeURIComponent(id);
 }
 
 function resolveCopilotHome() {

--- a/.canvas/extension.mjs
+++ b/.canvas/extension.mjs
@@ -312,6 +312,10 @@ const ASSETS = {
   '/index.html': { path: join(__dirname, 'index.html'), type: 'text/html; charset=utf-8' },
   '/app.js': { path: join(__dirname, 'app.js'), type: 'application/javascript' },
   '/styles.css': { path: join(__dirname, 'styles.css'), type: 'text/css' },
+  '/vendor/marked.esm.js': {
+    path: join(__dirname, 'node_modules', 'marked', 'lib', 'marked.esm.js'),
+    type: 'application/javascript',
+  },
 };
 
 async function serveAsset(req, res, asset) {
@@ -391,12 +395,13 @@ async function main() {
   startWatching();
   await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
   const { port } = server.address();
-  const baseUrl = `http://127.0.0.1:${port}/?t=${LOOPBACK_TOKEN}`;
-  // The runtime would normally receive this URL via the SDK's open() return
-  // value. For standalone runs we log the token-bearing URL so a developer
-  // can paste it directly. The token never travels off-loopback.
-  console.log(`[sensei-canvas] listening on ${baseUrl}`);
+  const baseUrl = `http://127.0.0.1:${port}/`;
   if (!process.env.COPILOT_CANVAS_LOOPBACK_TOKEN) {
+    // Standalone / dev: log the full token-bearing URL so the developer
+    // can paste it directly into a browser. The token never travels
+    // off-loopback.
+    const standaloneUrl = `${baseUrl}?t=${LOOPBACK_TOKEN}`;
+    console.log(`[sensei-canvas] listening on ${standaloneUrl}`);
     // Loud warning — if the Copilot CLI runtime spawned us with a
     // different env-var name (or didn't inject a token at all), the host
     // iframe will be handed a token we don't know about and every data
@@ -411,6 +416,11 @@ async function main() {
         '[sensei-canvas]     Likely cause: runtime injects under a different env-var name.\n' +
         '[sensei-canvas]     File an issue against spboyer/sensei if you see this in production.'
     );
+  } else {
+    // Runtime-spawned: log only the base URL to avoid leaking the loopback
+    // token into host process logs. The runtime delivers the token to the
+    // iframe through its own channel.
+    console.log(`[sensei-canvas] listening on ${baseUrl}`);
   }
   console.log(`[sensei-canvas] artifacts: ${ARTIFACTS_DIR}`);
 }

--- a/.canvas/extension.mjs
+++ b/.canvas/extension.mjs
@@ -116,6 +116,15 @@ function broadcast() {
  * Read newly appended bytes from an NDJSON file and push parsed objects
  * into state.steps. Tolerates partial-line writes by leaving the trailing
  * non-newline-terminated fragment in the offset (we re-read it next time).
+ *
+ * Byte-offset tracking is load-bearing: on the **first** call for a
+ * given run (after `syncStateFromDisk` discovers a pre-existing run dir
+ * — the cross-session reopen path, integration test A6) we DO read from
+ * byte 0 and ingest the full history. On every subsequent call we read
+ * only the appended bytes. Without this, every bursty fs.watch event
+ * (A4) would re-emit the historical step record set as if it were new,
+ * and SSE clients would see N copies of step 1 by the time step N
+ * fires. Do not "simplify" this by always reading from 0.
  */
 async function tailStepsFile(path) {
   if (!existsSync(path)) return;

--- a/.canvas/extension.mjs
+++ b/.canvas/extension.mjs
@@ -231,6 +231,67 @@ function startWatching() {
 }
 
 // ---------------------------------------------------------------------------
+// Loopback-token validation (stub)
+// ---------------------------------------------------------------------------
+
+/**
+ * Constant-time string equality. Returns false for length mismatch so the
+ * comparison still runs over zero bytes when lengths differ.
+ */
+function timingSafeEqual(a, b) {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+/**
+ * Per-instance loopback token used to gate every HTTP request.
+ *
+ * Resolution:
+ *   - `COPILOT_CANVAS_LOOPBACK_TOKEN` env var if set (set by the Copilot
+ *     CLI runtime when it spawns the provider).
+ *   - Otherwise, a 32-byte hex token generated once at startup and
+ *     logged so a developer running this standalone can copy the full
+ *     URL out of the log.
+ *
+ * The token only ever leaves this process via:
+ *   - The URL handed back to the runtime (production) or printed to
+ *     stdout (standalone dev).
+ *   - The iframe page, which reads `?t=...` from its own `location` and
+ *     forwards it on every fetch + EventSource URL.
+ */
+import { randomBytes } from 'node:crypto';
+const LOOPBACK_TOKEN =
+  process.env.COPILOT_CANVAS_LOOPBACK_TOKEN ?? randomBytes(32).toString('hex');
+
+/**
+ * Stub for `validateLoopbackToken` from `@github/copilot-sdk/extension`.
+ *
+ * Signature is pinned to match the eventual SDK export so call sites
+ * stay stable through the swap:
+ *
+ *     validateLoopbackToken(req: IncomingMessage, instanceId: string): boolean
+ *
+ * The `instanceId` parameter is reserved for the SDK's per-instance
+ * token registry; this stub ignores it because we have exactly one
+ * provider process and one effective instance.
+ *
+ * Accepts the token from either the `t` query parameter (used by the
+ * iframe so EventSource and fetch can include it) or an
+ * `X-Copilot-Canvas-Token` header (useful for command-line testing).
+ */
+// eslint-disable-next-line no-unused-vars
+function validateLoopbackToken(req, _instanceId) {
+  const url = new URL(req.url, 'http://127.0.0.1');
+  const fromQuery = url.searchParams.get('t');
+  const fromHeader = req.headers['x-copilot-canvas-token'];
+  const provided = fromQuery ?? (typeof fromHeader === 'string' ? fromHeader : null);
+  if (!provided) return false;
+  return timingSafeEqual(provided, LOOPBACK_TOKEN);
+}
+
+// ---------------------------------------------------------------------------
 // HTTP / SSE server
 // ---------------------------------------------------------------------------
 
@@ -254,11 +315,23 @@ async function serveAsset(req, res, asset) {
 
 const server = http.createServer(async (req, res) => {
   const url = new URL(req.url, 'http://127.0.0.1');
-  // TODO(sdk): once @github/copilot-sdk/extension ships, gate every
-  // request on validateLoopbackToken(req, instanceId). Today there's no
-  // token because there's no runtime issuing one.
   const asset = ASSETS[url.pathname];
+
+  // Static assets (HTML/CSS/JS) carry no user data and are served
+  // unauthenticated so the iframe can boot from a simple
+  // `<script src="./app.js">`. The iframe then forwards the loopback
+  // token on every data-endpoint request below.
   if (req.method === 'GET' && asset) return serveAsset(req, res, asset);
+
+  // Token-gate every data endpoint. Once `@github/copilot-sdk/extension`
+  // ships, the local `validateLoopbackToken` stub is replaced by the
+  // SDK export — call site stays the same because the signature is
+  // pinned.
+  if (!validateLoopbackToken(req, /* instanceId */ 'sensei')) {
+    res.writeHead(403, { 'Content-Type': 'text/plain' });
+    res.end('forbidden');
+    return;
+  }
 
   if (req.method === 'GET' && url.pathname === '/state') {
     res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -307,8 +380,12 @@ async function main() {
   await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
   const { port } = server.address();
   // The runtime would normally receive this URL via the SDK's open() return
-  // value. For standalone runs we log it so a developer can open it directly.
-  console.log(`[sensei-canvas] listening on http://127.0.0.1:${port}/`);
+  // value. For standalone runs we log the token-bearing URL so a developer
+  // can paste it directly. The token never travels off-loopback.
+  console.log(`[sensei-canvas] listening on http://127.0.0.1:${port}/?t=${LOOPBACK_TOKEN}`);
+  if (!process.env.COPILOT_CANVAS_LOOPBACK_TOKEN) {
+    console.log('[sensei-canvas] using ephemeral loopback token (set COPILOT_CANVAS_LOOPBACK_TOKEN to override)');
+  }
   console.log(`[sensei-canvas] artifacts: ${ARTIFACTS_DIR}`);
 }
 

--- a/.canvas/extension.mjs
+++ b/.canvas/extension.mjs
@@ -379,12 +379,26 @@ async function main() {
   startWatching();
   await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
   const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}/?t=${LOOPBACK_TOKEN}`;
   // The runtime would normally receive this URL via the SDK's open() return
   // value. For standalone runs we log the token-bearing URL so a developer
   // can paste it directly. The token never travels off-loopback.
-  console.log(`[sensei-canvas] listening on http://127.0.0.1:${port}/?t=${LOOPBACK_TOKEN}`);
+  console.log(`[sensei-canvas] listening on ${baseUrl}`);
   if (!process.env.COPILOT_CANVAS_LOOPBACK_TOKEN) {
-    console.log('[sensei-canvas] using ephemeral loopback token (set COPILOT_CANVAS_LOOPBACK_TOKEN to override)');
+    // Loud warning — if the Copilot CLI runtime spawned us with a
+    // different env-var name (or didn't inject a token at all), the host
+    // iframe will be handed a token we don't know about and every data
+    // request will 403. The operator sees an empty canvas with no
+    // obvious cause. This message points at the likely fix.
+    console.warn(
+      '[sensei-canvas] WARNING: COPILOT_CANVAS_LOOPBACK_TOKEN not set; ' +
+        'using an ephemeral token generated at startup.\n' +
+        '[sensei-canvas]   - Standalone / dev: open the URL above directly; it works.\n' +
+        '[sensei-canvas]   - Spawned by Copilot CLI runtime: the host iframe will 403 every\n' +
+        '[sensei-canvas]     data request because the runtime told it a different token.\n' +
+        '[sensei-canvas]     Likely cause: runtime injects under a different env-var name.\n' +
+        '[sensei-canvas]     File an issue against spboyer/sensei if you see this in production.'
+    );
   }
   console.log(`[sensei-canvas] artifacts: ${ARTIFACTS_DIR}`);
 }

--- a/.canvas/index.html
+++ b/.canvas/index.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Sensei</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Sensei</h1>
+      <span id="status" class="status status--idle">Idle</span>
+    </header>
+
+    <main>
+      <section id="view-idle" class="view" hidden>
+        <p class="empty">
+          No sensei runs yet. Start one from chat &mdash; <code>run sensei on &lt;skill&gt;</code> &mdash; and progress will stream here.
+        </p>
+      </section>
+
+      <section id="view-running" class="view" hidden>
+        <div class="run-meta">
+          <span>Run</span>
+          <code id="running-run-id"></code>
+        </div>
+        <ol id="steps-list" aria-live="polite"></ol>
+      </section>
+
+      <section id="view-report" class="view" hidden>
+        <div class="run-meta">
+          <span>Last run</span>
+          <code id="report-run-id"></code>
+        </div>
+        <article id="report-md"></article>
+      </section>
+    </main>
+
+    <script type="module" src="./app.js"></script>
+  </body>
+</html>

--- a/.canvas/package-lock.json
+++ b/.canvas/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "sensei-canvas",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sensei-canvas",
+      "version": "0.1.0",
+      "dependencies": {
+        "marked": "^12.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    }
+  }
+}

--- a/.canvas/package.json
+++ b/.canvas/package.json
@@ -8,9 +8,11 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "marked": "^12.0.0"
+  },
   "comments": {
     "sdk-pending": "Once @github/copilot-sdk/extension ships, add it as a dependency and wire createCanvas + joinSession + validateLoopbackToken in extension.mjs. Until then, extension.mjs runs as a standalone HTTP + SSE + watcher process so we can iterate on the iframe and watcher logic independently of the SDK contract.",
-    "marked-via-cdn": "marked is loaded from cdn.jsdelivr.net by app.js to keep the .canvas package zero-deps for now. When we land the SDK shim we can vendor it locally if we want to support offline use."
+    "marked-via-cdn": "marked was previously loaded from cdn.jsdelivr.net. It is now added as a local dependency (see package.json) and served by extension.mjs so the canvas works offline and carries no CDN supply-chain risk."
   }
 }

--- a/.canvas/package.json
+++ b/.canvas/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "sensei-canvas",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Canvas provider for the sensei skill — renders Ralph-loop progress and reports in a Copilot CLI side panel.",
+  "type": "module",
+  "main": "extension.mjs",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {},
+  "comments": {
+    "sdk-pending": "Once @github/copilot-sdk/extension ships, add it as a dependency and wire createCanvas + joinSession + validateLoopbackToken in extension.mjs. Until then, extension.mjs runs as a standalone HTTP + SSE + watcher process so we can iterate on the iframe and watcher logic independently of the SDK contract.",
+    "marked-via-cdn": "marked is loaded from cdn.jsdelivr.net by app.js to keep the .canvas package zero-deps for now. When we land the SDK shim we can vendor it locally if we want to support offline use."
+  }
+}

--- a/.canvas/styles.css
+++ b/.canvas/styles.css
@@ -1,0 +1,148 @@
+:root {
+  --bg: #0d1117;
+  --fg: #c9d1d9;
+  --muted: #8b949e;
+  --accent: #58a6ff;
+  --border: #30363d;
+  --running: #d29922;
+  --complete: #3fb950;
+  --idle: #8b949e;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border);
+}
+
+h1 {
+  font-size: 1rem;
+  margin: 0;
+  letter-spacing: 0.02em;
+}
+
+.status {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+}
+
+.status--idle {
+  color: var(--idle);
+}
+
+.status--running {
+  color: var(--running);
+  border-color: var(--running);
+}
+
+.status--complete {
+  color: var(--complete);
+  border-color: var(--complete);
+}
+
+main {
+  padding: 1rem;
+  overflow: auto;
+  height: calc(100vh - 50px);
+}
+
+.view {
+  display: block;
+}
+
+.empty {
+  color: var(--muted);
+  text-align: center;
+  margin-top: 4rem;
+}
+
+code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85em;
+  background: rgba(110, 118, 129, 0.1);
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+}
+
+.run-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--muted);
+  margin-bottom: 0.75rem;
+}
+
+#steps-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.step {
+  display: grid;
+  grid-template-columns: 90px 110px 1fr;
+  gap: 0.5rem;
+  padding: 0.35rem 0;
+  border-bottom: 1px solid var(--border);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85rem;
+}
+
+.step-time {
+  color: var(--muted);
+}
+
+.step-tag {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+#report-md h1,
+#report-md h2,
+#report-md h3 {
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0.25rem;
+}
+
+#report-md table {
+  border-collapse: collapse;
+  margin: 1rem 0;
+}
+
+#report-md th,
+#report-md td {
+  border: 1px solid var(--border);
+  padding: 0.35rem 0.6rem;
+  text-align: left;
+}
+
+#report-md th {
+  background: rgba(110, 118, 129, 0.1);
+}
+
+#report-md a {
+  color: var(--accent);
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,11 @@
 .ai-team/agents/*/history.md merge=union
 .ai-team/log/** merge=union
 .ai-team/orchestration-log/** merge=union
+
+# Canvas: side-panel UI used by Copilot CLI. Not relevant to git archive
+# tarballs or release downloads — consumers who want the canvas pull the
+# repo directly (e.g. via `npx skills add`). Keeps `npm pack` / GitHub
+# release tarballs lean and prevents the canvas's runtime deps from
+# leaking into CI/Action consumers that only use the `sensei` CLI.
+.canvas/ export-ignore
+references/canvas.md export-ignore

--- a/.token-limits.json
+++ b/.token-limits.json
@@ -8,7 +8,7 @@
     "*.md": 4000
   },
   "overrides": {
-    "README.md": 4200,
+    "README.md": 4400,
     "AGENTS.md": 2000,
     "references/scoring.md": 4500,
     "references/examples.md": 4000,

--- a/.token-limits.json
+++ b/.token-limits.json
@@ -12,6 +12,7 @@
     "AGENTS.md": 2000,
     "references/scoring.md": 4500,
     "references/examples.md": 4000,
-    "references/loop.md": 2500
+    "references/loop.md": 2500,
+    "references/canvas.md": 2500
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ sensei/
 │   ├── scoring.md        # Scoring algorithm details
 │   ├── mcp-integration.md # MCP tool integration patterns
 │   ├── loop.md           # Ralph loop workflow
+│   ├── canvas.md         # Copilot CLI canvas integration
 │   ├── examples.md       # Before/after transformations
 │   ├── configuration.md  # Project config patterns
 │   └── test-templates/   # Framework-specific test templates
@@ -27,6 +28,10 @@ sensei/
 │       ├── pytest.md     # pytest test template
 │       ├── waza.md       # Waza trigger test format
 │       └── ...
+├── .canvas/              # Copilot CLI canvas (side-panel UI; optional)
+│   ├── extension.mjs     # Provider: watches artifacts dir, serves iframe
+│   ├── index.html, app.js, styles.css
+│   └── package.json
 └── scripts/              # TypeScript token management tools
     ├── package.json      # Dependencies (tsx, vitest, typescript)
     ├── tsconfig.json
@@ -41,7 +46,10 @@ sensei/
         │       ├── check.ts  # Limit validation
         │       ├── suggest.ts # Optimization suggestions
         │       ├── compare.ts # Git-based comparison
-        │       └── score.ts  # Advisory scoring
+        │       ├── score.ts  # Advisory scoring
+        │       ├── artifacts.ts # Canvas artifact path resolution
+        │       ├── step.ts   # `sensei step` — append progress NDJSON
+        │       └── report.ts # `sensei report --finalize` — write report.md
         └── gepa/
             ├── auto_evaluator.py  # GEPA auto-evaluator CLI
             └── requirements.txt   # Python dependencies (gepa)
@@ -117,6 +125,9 @@ See `references/mcp-integration.md` for patterns.
 - Remove trigger or anti-trigger phrases without replacement
 - Omit INVOKES when skill calls MCP tools or other skills
 - Embed CLI commands without MCP option when MCP tools exist
+- Branch the Ralph loop on canvas availability. The canvas is an optional
+  UI surface; `sensei step` / `sensei report --finalize` are best-effort
+  writes that always succeed. Chat output is the primary surface.
 
 ## Testing Changes
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,22 @@ Sensei automates the improvement of [Agent Skills](https://support.anthropic.com
 - [Quick Start](#quick-start)
 - [Prerequisites](#prerequisites)
 - [How It Works](#how-it-works)
+- [Canvas](#canvas)
 - [Configuration](#configuration)
 - [Scoring Criteria](#scoring-criteria)
 - [Examples](#examples)
 - [Troubleshooting](#troubleshooting)
 - [Contributing](#contributing)
+
+---
+
+## Canvas
+
+Sensei ships an optional [Copilot CLI canvas](.canvas/) that opens in the
+side panel during a run, streaming per-step progress and switching to a
+browsable report on completion. The agent feeds it via `sensei step` and
+`sensei report --finalize` — no RPC, crash-safe, no-op when no canvas is
+watching. See [references/canvas.md](references/canvas.md).
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -259,6 +259,39 @@ Ask how to proceed:
 - If score < Medium-High AND iterations < 5 → go to Step 2
 - If iterations >= 5 → timeout, show summary, move to next skill
 
+After the run completes (all skills processed), finalize the canvas report:
+
+```bash
+echo '{"title":"sensei run","skills":[...],"notes":"..."}' \
+  | npx @spboyer/sensei report --finalize --run-id $RUN_ID --input -
+```
+
+## Canvas Integration (optional)
+
+When the [sensei canvas](.canvas/) is open, you can stream Ralph-loop progress
+to it so the user sees live updates in the side panel. This is **best-effort**
+— the canvas commands always succeed; if no canvas is watching the writes are
+just a no-op. Never branch the Ralph loop on canvas availability.
+
+**Generate a run id once at the start of a sensei invocation:**
+
+```bash
+RUN_ID=$(node -e 'console.log(Date.now().toString(36).toUpperCase() + Math.random().toString(36).slice(2,10).toUpperCase())')
+```
+
+**After each numbered Ralph step, append a JSON record:**
+
+```bash
+npx @spboyer/sensei step --run-id "$RUN_ID" --append \
+  '{"step":"SCORE","skill":"pdf","score":"Medium","message":"+1 trigger"}'
+```
+
+Recommended fields: `step` (READ/SCORE/IMPROVE/...), `skill`, `score`,
+`tokens`, `message`. The `t` timestamp is auto-stamped if absent.
+
+**At the end of the run, finalize the report** (see Step 11 above). The
+canvas auto-switches to the report view when `report.md` appears.
+
 ## Scoring Quick Reference
 
 | Score | Requirements |

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,9 @@
 ---
 name: sensei
 description: "**WORKFLOW SKILL** — Iteratively improve skill frontmatter compliance using the Ralph loop pattern. WHEN: \"run sensei\", \"sensei help\", \"improve skill\", \"fix frontmatter\", \"skill compliance\", \"frontmatter audit\", \"score skill\", \"check skill tokens\". INVOKES: token counting tools, test runners, git commands. FOR SINGLE OPERATIONS: use token CLI directly for counts/checks."
-canvas: true
+metadata:
+  copilot:
+    canvas: true
 ---
 
 # Sensei

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: sensei
 description: "**WORKFLOW SKILL** — Iteratively improve skill frontmatter compliance using the Ralph loop pattern. WHEN: \"run sensei\", \"sensei help\", \"improve skill\", \"fix frontmatter\", \"skill compliance\", \"frontmatter audit\", \"score skill\", \"check skill tokens\". INVOKES: token counting tools, test runners, git commands. FOR SINGLE OPERATIONS: use token CLI directly for counts/checks."
+canvas: true
 ---
 
 # Sensei

--- a/references/canvas.md
+++ b/references/canvas.md
@@ -86,7 +86,78 @@ Linux ext4, and is reversible. The CLI helper lives in
 an identical copy lives in `.canvas/extension.mjs`.
 
 `latest.txt` is a plain file, not a symlink, because Windows symlinks
-require elevated privileges by default.
+require elevated privileges by default. Other canvas authors should
+follow the same convention if they need a "current run" pointer.
+
+## Step payload schema
+
+`sensei step --append <json>` accepts any JSON object; the iframe and
+any future watcher consume fields opportunistically. Recommended shape
+(this is a copy-friendly reference contract for other skills that want
+to build a canvas the same way):
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/spboyer/sensei/refs/heads/main/references/canvas.md#step-schema",
+  "title": "SenseiCanvasStep",
+  "description": "One Ralph-loop step record. Appended as a single NDJSON line to runs/<id>/steps.ndjson.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "t": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 timestamp. Auto-stamped by `sensei step` if absent."
+    },
+    "step": {
+      "type": "string",
+      "description": "Ralph-loop step tag, e.g. READ, SCORE, SCAFFOLD, IMPROVE, VERIFY, TOKENS, SUMMARY.",
+      "examples": ["READ", "SCORE", "IMPROVE", "VERIFY"]
+    },
+    "skill": {
+      "type": "string",
+      "description": "Name of the skill being processed."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["ok", "warn", "error"],
+      "description": "Outcome of the step. Optional; default is success."
+    },
+    "score": {
+      "oneOf": [
+        { "type": "string", "enum": ["Low", "Medium", "Medium-High", "High"] },
+        { "type": "number" }
+      ],
+      "description": "Compliance score after this step. Either the canonical adherence label or a numeric score."
+    },
+    "tokens": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Token count for the skill after this step."
+    },
+    "delta": {
+      "type": "integer",
+      "description": "Score change relative to the previous step for this skill (positive = improvement)."
+    },
+    "message": {
+      "type": "string",
+      "description": "Short human-readable summary of what the step did. Rendered as the step row's right column."
+    }
+  }
+}
+```
+
+All properties are optional. `additionalProperties: true` is intentional
+so future fields don't break older watchers. The iframe renders `t`,
+`step`/`phase`, `skill`, `score`, and `message`/`lastAction` if present.
+
+This schema is informational; `sensei step` does **not** validate
+incoming JSON against it. The CLI's only invariant is that the payload
+parses as a JSON object (arrays and primitives are rejected). Strict
+validation belongs in the agent's prompt or in a dedicated lint pass,
+not in the hot path.
+
 
 ## Overriding the artifact path
 

--- a/references/canvas.md
+++ b/references/canvas.md
@@ -21,9 +21,10 @@ poll, and reopening the canvas mid-run replays the in-progress state.
 chat agent ──▶ npx @spboyer/sensei step  ──┐
 chat agent ──▶ npx @spboyer/sensei report ─┤
                                             ▼
-                          $COPILOT_HOME/extensions/
-                            skill__github.com_spboyer_sensei__sensei/
-                            artifacts/runs/<ULID>/{steps.ndjson, report.md}
+                          $COPILOT_EXTENSION_ARTIFACTS_DIR/  (set by runtime)
+                            or $COPILOT_HOME/extensions/
+                              skill%3Agithub.com%2Fspboyer%2Fsensei%3Asensei/
+                              artifacts/runs/<run-id>/{steps.ndjson, report.md}
                                             ▲
                           .canvas/extension.mjs (fs.watch + HTTP/SSE)
                                             ▼

--- a/references/canvas.md
+++ b/references/canvas.md
@@ -78,12 +78,23 @@ $COPILOT_HOME/extensions/<encoded-id>/artifacts/
     └── latest.txt          # text file containing the most recent ULID
 ```
 
-`<encoded-id>` is the canonical extension id (`skill:github.com/spboyer/sensei:sensei`)
-with `:` replaced by `__`, `/` by `_`, and lowercased. The encoding
-keeps the path valid on Windows NTFS (`:` is illegal), macOS APFS, and
-Linux ext4, and is reversible. The CLI helper lives in
-`scripts/src/tokens/commands/artifacts.ts` and is pinned by a unit test;
-an identical copy lives in `.canvas/extension.mjs`.
+`<encoded-id>` is the canonical extension id
+(`skill:github.com/spboyer/sensei:sensei`) passed through
+`encodeURIComponent`. Result for sensei:
+`skill%3Agithub.com%2Fspboyer%2Fsensei%3Asensei`. Percent-encoding is
+RFC-defined, fully reversible (`decodeURIComponent`), and produces only
+characters that are safe on Windows NTFS, macOS APFS, and Linux ext4
+(`%` is legal in path components on all three). This matches the
+Copilot CLI runtime's encoding so dev/test paths line up with what the
+runtime would compute.
+
+The CLI helper lives in `scripts/src/tokens/commands/artifacts.ts` and
+is pinned by a unit test; an identical copy lives in
+`.canvas/extension.mjs`. In production both **read
+`COPILOT_EXTENSION_ARTIFACTS_DIR` from the environment** rather than
+computing the path themselves — the runtime sets it when it spawns the
+provider, so writer and reader always agree even if the encoding scheme
+evolves later.
 
 `latest.txt` is a plain file, not a symlink, because Windows symlinks
 require elevated privileges by default. Other canvas authors should

--- a/references/canvas.md
+++ b/references/canvas.md
@@ -199,17 +199,21 @@ also accepts an `X-Copilot-Canvas-Token` header for command-line use.
 Token comparison is constant-time.
 
 `.canvas/extension.mjs` currently ships a local `validateLoopbackToken`
-helper with this signature (pinned to match the eventual SDK export):
+helper with this signature (pinned to match the SDK export per runtime
+spec §11):
 
 ```ts
-validateLoopbackToken(req: IncomingMessage, instanceId: string): boolean
+validateLoopbackToken(req: IncomingMessage): boolean
 ```
 
+Runtime adopted the per-process-token design — every provider fork
+(including reload restarts) gets a fresh token via the env var, so the
+helper takes only the request. The token MUST NOT be cached across
+reload boundaries; this is naturally satisfied because reloads kill and
+re-spawn the provider (fresh module = fresh env-var read).
+
 Once `@github/copilot-sdk/extension` ships the helper, the local stub
-is replaced by the SDK export. Call sites stay the same. The
-`instanceId` parameter is reserved for the SDK's per-instance token
-registry; the stub ignores it because there's one provider, one
-effective instance.
+is replaced by the SDK export. Call sites stay the same.
 
 ## SDK integration (pending)
 

--- a/references/canvas.md
+++ b/references/canvas.md
@@ -177,6 +177,40 @@ Copilot CLI runtime sets this when it spawns the provider so the writer
 and reader always agree on the path. The CLI also accepts
 `--artifacts-dir <path>` for tests and local development.
 
+## Loopback-token validation
+
+The canvas's HTTP server gates every **data** endpoint (`/state`,
+`/events`, `/report`) on a per-process loopback token; only the iframe,
+which receives the token in its bootstrap URL, can read run state.
+Static assets (`/`, `/index.html`, `/app.js`, `/styles.css`) are
+unauthenticated so the iframe can boot from a plain `<script>` tag.
+
+Token resolution:
+
+1. `COPILOT_CANVAS_LOOPBACK_TOKEN` env var, set by the Copilot CLI
+   runtime when it spawns the provider.
+2. If unset (standalone dev), a 32-byte hex token is generated at
+   startup and printed to stdout as part of the listening URL, so a
+   developer can paste the full URL into a browser.
+
+The iframe forwards the token via the `?t=` query string on every
+`fetch` and on the `EventSource('/events?t=...')` URL. The provider
+also accepts an `X-Copilot-Canvas-Token` header for command-line use.
+Token comparison is constant-time.
+
+`.canvas/extension.mjs` currently ships a local `validateLoopbackToken`
+helper with this signature (pinned to match the eventual SDK export):
+
+```ts
+validateLoopbackToken(req: IncomingMessage, instanceId: string): boolean
+```
+
+Once `@github/copilot-sdk/extension` ships the helper, the local stub
+is replaced by the SDK export. Call sites stay the same. The
+`instanceId` parameter is reserved for the SDK's per-instance token
+registry; the stub ignores it because there's one provider, one
+effective instance.
+
 ## SDK integration (pending)
 
 `.canvas/extension.mjs` runs as a standalone HTTP + SSE + watcher process

--- a/references/canvas.md
+++ b/references/canvas.md
@@ -1,0 +1,111 @@
+# Canvas
+
+Sensei ships an optional Copilot CLI canvas at `.canvas/`. When trusted,
+the Copilot CLI runtime opens it in the side panel during a sensei run so
+the user sees live Ralph-loop progress and a browsable report afterward.
+
+## What the user sees
+
+| Phase | View |
+|---|---|
+| Idle | Empty state with instructions to start a run. |
+| Running | Per-step list (timestamp, step tag, skill, message, score) that streams as the agent works. |
+| Complete | Rendered markdown report (per-skill before/after scores, decisions, notes). |
+
+The phase auto-switches based on what's on disk — the iframe never has to
+poll, and reopening the canvas mid-run replays the in-progress state.
+
+## How it works
+
+```
+chat agent ──▶ npx @spboyer/sensei step  ──┐
+chat agent ──▶ npx @spboyer/sensei report ─┤
+                                            ▼
+                          $COPILOT_HOME/extensions/
+                            skill__github.com_spboyer_sensei__sensei/
+                            artifacts/runs/<ULID>/{steps.ndjson, report.md}
+                                            ▲
+                          .canvas/extension.mjs (fs.watch + HTTP/SSE)
+                                            ▼
+                                    iframe (index.html + app.js)
+```
+
+There is **no RPC contract** between the agent and the canvas. The agent
+writes NDJSON via the CLI; the canvas provider tails the file and
+broadcasts via Server-Sent Events. This means:
+
+- The agent never branches on "is the canvas open and trusted?" — it just
+  runs the CLI. If no canvas is watching, the writes are still durable on
+  disk (useful for replay later) and chat output is unchanged.
+- Any future writer (CI, a headless script, GEPA) can feed the canvas
+  without learning a new API.
+
+## The CLI surface
+
+### `sensei step --run-id <ulid> --append <json|->`
+
+Append one Ralph-step record to the active run's `steps.ndjson` and
+update `runs/latest.txt`. On the first call for a run, the run directory
+and `manifest.json` are seeded.
+
+Use `-` to read JSON from stdin (useful for large records):
+
+```bash
+echo '{"step":"SCORE","skill":"pdf","score":"Medium-High","message":"trigger phrases added"}' \
+  | npx @spboyer/sensei step --run-id "$RUN_ID" --append -
+```
+
+The `t` field is auto-stamped with the current ISO timestamp if absent.
+The payload must be a JSON object; arrays and primitives are rejected.
+
+### `sensei report --finalize --run-id <ulid> --input <path|->`
+
+Render the final markdown report and mark the run complete. The input is
+a JSON `RunSummary` (see `scripts/src/tokens/commands/report.ts` for the
+type). On finalize, `manifest.json` is updated with `finishedAt` and the
+input summary, `report.md` is written, and `runs/latest.txt` points at
+this run.
+
+## Artifact layout
+
+```
+$COPILOT_HOME/extensions/<encoded-id>/artifacts/
+└── runs/
+    ├── 01ABCDEF.../
+    │   ├── manifest.json   # { runId, startedAt, finishedAt, schemaVersion, summary }
+    │   ├── steps.ndjson    # append-only, one JSON object per line
+    │   └── report.md       # written at finalize
+    └── latest.txt          # text file containing the most recent ULID
+```
+
+`<encoded-id>` is the canonical extension id (`skill:github.com/spboyer/sensei:sensei`)
+with `:` replaced by `__`, `/` by `_`, and lowercased. The encoding
+keeps the path valid on Windows NTFS (`:` is illegal), macOS APFS, and
+Linux ext4, and is reversible. The CLI helper lives in
+`scripts/src/tokens/commands/artifacts.ts` and is pinned by a unit test;
+an identical copy lives in `.canvas/extension.mjs`.
+
+`latest.txt` is a plain file, not a symlink, because Windows symlinks
+require elevated privileges by default.
+
+## Overriding the artifact path
+
+The provider and the CLI both honor `COPILOT_EXTENSION_ARTIFACTS_DIR`. The
+Copilot CLI runtime sets this when it spawns the provider so the writer
+and reader always agree on the path. The CLI also accepts
+`--artifacts-dir <path>` for tests and local development.
+
+## SDK integration (pending)
+
+`.canvas/extension.mjs` runs as a standalone HTTP + SSE + watcher process
+today so the iframe and watcher can be iterated on independently of the
+`@github/copilot-sdk/extension` package. When the SDK ships, three things
+change at the bottom of the file:
+
+1. Wrap the registration in `joinSession({ canvases: [createCanvas(...)] })`.
+2. Return `{ url, title }` (with a per-instance loopback token) from the
+   canvas's `open()` handler instead of logging the URL.
+3. Validate the loopback token on every request via
+   `validateLoopbackToken(req, instanceId)`.
+
+The watcher, SSE, and file format do not change.

--- a/scripts/src/tokens/cli.test.ts
+++ b/scripts/src/tokens/cli.test.ts
@@ -41,6 +41,38 @@ describe('parseArgs', () => {
     expect(() => parseArgs(['check', '--root'])).toThrow('Missing value for --root');
     expect(() => parseArgs(['check', '--config', '--strict'])).toThrow('Missing value for --config');
   });
+
+  it('parses canvas-related options for the step command', () => {
+    const parsed = parseArgs([
+      'step',
+      '--run-id=01ABC',
+      '--append',
+      '{"x":1}',
+      '--artifacts-dir=/tmp/a',
+    ]);
+    expect(parsed.command).toBe('step');
+    expect(parsed.options).toMatchObject({
+      runId: '01ABC',
+      append: '{"x":1}',
+      artifactsDir: '/tmp/a',
+    });
+  });
+
+  it('parses canvas-related options for the report command', () => {
+    const parsed = parseArgs([
+      'report',
+      '--finalize',
+      '--run-id',
+      '01XYZ',
+      '--input=-',
+    ]);
+    expect(parsed.command).toBe('report');
+    expect(parsed.options).toMatchObject({
+      finalize: true,
+      runId: '01XYZ',
+      input: '-',
+    });
+  });
 });
 
 describe('main help', () => {

--- a/scripts/src/tokens/cli.ts
+++ b/scripts/src/tokens/cli.ts
@@ -118,11 +118,11 @@ export function parseArgs(args: string[]): { command: string; paths: string[]; o
     } else if (arg.startsWith('--run-id=')) {
       options.runId = arg.slice(9);
     } else if (arg === '--append') {
-      options.append = readOptionValue(args, ++i, '--append');
+      options.append = readOptionValue(args, ++i, '--append', true);
     } else if (arg.startsWith('--append=')) {
       options.append = arg.slice(9);
     } else if (arg === '--input') {
-      options.input = readOptionValue(args, ++i, '--input');
+      options.input = readOptionValue(args, ++i, '--input', true);
     } else if (arg.startsWith('--input=')) {
       options.input = arg.slice(8);
     } else if (arg === '--finalize') {
@@ -142,13 +142,13 @@ export function parseArgs(args: string[]): { command: string; paths: string[]; o
   return { command, paths, options };
 }
 
-function readOptionValue(args: string[], index: number, optionName: string): string {
+function readOptionValue(args: string[], index: number, optionName: string, allowStdin = false): string {
   const value = args[index];
   if (value === undefined) {
     throw new Error(`Missing value for ${optionName}`);
   }
-  // Allow the literal `-` as a value (used to mean "read from stdin").
-  if (value === '-') return value;
+  // Allow the literal `-` only for stdin-backed options (--append, --input).
+  if (value === '-' && allowStdin) return value;
   if (value.startsWith('-')) {
     throw new Error(`Missing value for ${optionName}`);
   }

--- a/scripts/src/tokens/cli.ts
+++ b/scripts/src/tokens/cli.ts
@@ -13,7 +13,7 @@
 import { existsSync, realpathSync, statSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { count, check, suggest, compare, scoreSkill } from './commands/index.js';
+import { count, check, suggest, compare, scoreSkill, step, report } from './commands/index.js';
 import { getErrorMessage } from './commands/types.js';
 import { resolvePathFromRoot, resolveRootDir } from './commands/utils.js';
 
@@ -31,6 +31,13 @@ Commands:
   suggest [paths...]   Get optimization suggestions
   compare [refs...]    Compare tokens between git refs
   score [path]         Score a skill directory against SkillsBench criteria
+  step --run-id <id> --append <json|->
+                       Append a Ralph-loop step to the active run's
+                       steps.ndjson; updates runs/latest.txt. Feeds the
+                       sensei canvas.
+  report --finalize --run-id <id> --input <path|->
+                       Write the final report.md for a run from a JSON
+                       summary; updates manifest.json + latest.txt.
 
 Options:
   --format=<type>      Output format: json | table (default: table)
@@ -106,6 +113,24 @@ export function parseArgs(args: string[]): { command: string; paths: string[]; o
       options.config = readOptionValue(args, ++i, '--config');
     } else if (arg.startsWith('--config=')) {
       options.config = arg.slice(9);
+    } else if (arg === '--run-id') {
+      options.runId = readOptionValue(args, ++i, '--run-id');
+    } else if (arg.startsWith('--run-id=')) {
+      options.runId = arg.slice(9);
+    } else if (arg === '--append') {
+      options.append = readOptionValue(args, ++i, '--append');
+    } else if (arg.startsWith('--append=')) {
+      options.append = arg.slice(9);
+    } else if (arg === '--input') {
+      options.input = readOptionValue(args, ++i, '--input');
+    } else if (arg.startsWith('--input=')) {
+      options.input = arg.slice(8);
+    } else if (arg === '--finalize') {
+      options.finalize = true;
+    } else if (arg === '--artifacts-dir') {
+      options.artifactsDir = readOptionValue(args, ++i, '--artifacts-dir');
+    } else if (arg.startsWith('--artifacts-dir=')) {
+      options.artifactsDir = arg.slice(16);
     } else if (!arg.startsWith('-')) {
       paths.push(arg);
     } else {
@@ -119,13 +144,18 @@ export function parseArgs(args: string[]): { command: string; paths: string[]; o
 
 function readOptionValue(args: string[], index: number, optionName: string): string {
   const value = args[index];
-  if (!value || value.startsWith('-')) {
+  if (value === undefined) {
+    throw new Error(`Missing value for ${optionName}`);
+  }
+  // Allow the literal `-` as a value (used to mean "read from stdin").
+  if (value === '-') return value;
+  if (value.startsWith('-')) {
     throw new Error(`Missing value for ${optionName}`);
   }
   return value;
 }
 
-export function main(args = process.argv.slice(2)): void {
+export async function main(args = process.argv.slice(2)): Promise<void> {
   const { command, paths, options } = parseArgs(args);
 
   if (options.help || command === 'help') {
@@ -149,6 +179,30 @@ export function main(args = process.argv.slice(2)): void {
     case 'compare':
       compare(paths, options);
       break;
+
+    case 'step': {
+      await step({
+        runId: typeof options.runId === 'string' ? options.runId : undefined,
+        append: typeof options.append === 'string' ? options.append : undefined,
+        artifactsDir:
+          typeof options.artifactsDir === 'string' ? options.artifactsDir : undefined,
+      });
+      break;
+    }
+
+    case 'report': {
+      if (!options.finalize) {
+        console.error('Error: `sensei report` requires --finalize in v1.');
+        process.exit(1);
+      }
+      await report({
+        runId: typeof options.runId === 'string' ? options.runId : undefined,
+        input: typeof options.input === 'string' ? options.input : undefined,
+        artifactsDir:
+          typeof options.artifactsDir === 'string' ? options.artifactsDir : undefined,
+      });
+      break;
+    }
 
     case 'score': {
       const rootDir = resolveRootDir(typeof options.root === 'string' ? options.root : undefined);
@@ -209,10 +263,8 @@ function isEntrypoint(): boolean {
 }
 
 if (isEntrypoint()) {
-  try {
-    main();
-  } catch (error) {
+  main().catch((error) => {
     console.error(`Error: ${getErrorMessage(error)}`);
     process.exit(1);
-  }
+  });
 }

--- a/scripts/src/tokens/commands/artifacts.test.ts
+++ b/scripts/src/tokens/commands/artifacts.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import {
+  SENSEI_EXTENSION_ID,
+  encodeExtensionId,
+  resolveCopilotHome,
+  resolveArtifactsDir,
+  resolveRunDir,
+  resolveLatestPointerPath,
+} from './artifacts.js';
+
+describe('encodeExtensionId', () => {
+  it('pins the sensei canonical id mapping', () => {
+    // CRITICAL: this exact string is duplicated in .canvas/extension.mjs.
+    // If this test fails or you change it, update both places.
+    expect(encodeExtensionId(SENSEI_EXTENSION_ID)).toBe(
+      'skill__github.com_spboyer_sensei__sensei'
+    );
+  });
+
+  it('replaces colons with double underscores', () => {
+    expect(encodeExtensionId('a:b:c')).toBe('a__b__c');
+  });
+
+  it('replaces slashes with single underscores', () => {
+    expect(encodeExtensionId('a/b/c')).toBe('a_b_c');
+  });
+
+  it('lowercases the result', () => {
+    expect(encodeExtensionId('Skill:GitHub.com/Foo/Bar:Baz')).toBe(
+      'skill__github.com_foo_bar__baz'
+    );
+  });
+
+  it('produces only filesystem-safe characters', () => {
+    const encoded = encodeExtensionId(SENSEI_EXTENSION_ID);
+    expect(encoded).toMatch(/^[a-z0-9._-]+$/);
+  });
+});
+
+describe('resolveCopilotHome', () => {
+  const originalHome = process.env.COPILOT_HOME;
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.COPILOT_HOME;
+    else process.env.COPILOT_HOME = originalHome;
+  });
+
+  it('uses COPILOT_HOME when set', () => {
+    process.env.COPILOT_HOME = '/tmp/fake-copilot';
+    expect(resolveCopilotHome()).toBe('/tmp/fake-copilot');
+  });
+
+  it('falls back to $HOME/.copilot', () => {
+    delete process.env.COPILOT_HOME;
+    expect(resolveCopilotHome()).toBe(join(homedir(), '.copilot'));
+  });
+});
+
+describe('resolveArtifactsDir', () => {
+  const originalEnv = {
+    home: process.env.COPILOT_HOME,
+    dir: process.env.COPILOT_EXTENSION_ARTIFACTS_DIR,
+  };
+
+  beforeEach(() => {
+    delete process.env.COPILOT_EXTENSION_ARTIFACTS_DIR;
+  });
+
+  afterEach(() => {
+    if (originalEnv.home === undefined) delete process.env.COPILOT_HOME;
+    else process.env.COPILOT_HOME = originalEnv.home;
+    if (originalEnv.dir === undefined) delete process.env.COPILOT_EXTENSION_ARTIFACTS_DIR;
+    else process.env.COPILOT_EXTENSION_ARTIFACTS_DIR = originalEnv.dir;
+  });
+
+  it('honors explicit override above everything', () => {
+    process.env.COPILOT_EXTENSION_ARTIFACTS_DIR = '/env/dir';
+    expect(resolveArtifactsDir('/cli/dir')).toBe('/cli/dir');
+  });
+
+  it('honors COPILOT_EXTENSION_ARTIFACTS_DIR when no override', () => {
+    process.env.COPILOT_EXTENSION_ARTIFACTS_DIR = '/env/dir';
+    expect(resolveArtifactsDir()).toBe('/env/dir');
+  });
+
+  it('computes default from COPILOT_HOME + encoded id', () => {
+    process.env.COPILOT_HOME = '/tmp/copilot';
+    expect(resolveArtifactsDir()).toBe(
+      '/tmp/copilot/extensions/skill__github.com_spboyer_sensei__sensei/artifacts'
+    );
+  });
+});
+
+describe('resolveRunDir / resolveLatestPointerPath', () => {
+  it('places runs under <artifactsDir>/runs/<ULID>', () => {
+    expect(resolveRunDir('/a', '01JX')).toBe(join('/a', 'runs', '01JX'));
+  });
+
+  it('places latest pointer at <artifactsDir>/runs/latest.txt', () => {
+    expect(resolveLatestPointerPath('/a')).toBe(join('/a', 'runs', 'latest.txt'));
+  });
+});

--- a/scripts/src/tokens/commands/artifacts.test.ts
+++ b/scripts/src/tokens/commands/artifacts.test.ts
@@ -8,6 +8,7 @@ import {
   resolveArtifactsDir,
   resolveRunDir,
   resolveLatestPointerPath,
+  validateRunId,
 } from './artifacts.js';
 
 describe('encodeExtensionId', () => {
@@ -95,11 +96,47 @@ describe('resolveArtifactsDir', () => {
 });
 
 describe('resolveRunDir / resolveLatestPointerPath', () => {
-  it('places runs under <artifactsDir>/runs/<ULID>', () => {
+  it('places runs under <artifactsDir>/runs/<runId>', () => {
     expect(resolveRunDir('/a', '01JX')).toBe(join('/a', 'runs', '01JX'));
   });
 
   it('places latest pointer at <artifactsDir>/runs/latest.txt', () => {
     expect(resolveLatestPointerPath('/a')).toBe(join('/a', 'runs', 'latest.txt'));
+  });
+});
+
+describe('validateRunId', () => {
+  it('accepts a normal ULID-style id', () => {
+    expect(() => validateRunId('01JABCDEFGHJKMNPQRSTUVWXYZ')).not.toThrow();
+  });
+
+  it('accepts alphanumeric ids', () => {
+    expect(() => validateRunId('test-run-001')).not.toThrow();
+    expect(() => validateRunId('01ABC')).not.toThrow();
+  });
+
+  it('rejects an empty string', () => {
+    expect(() => validateRunId('')).toThrow('Invalid runId');
+  });
+
+  it('rejects ids with forward slashes', () => {
+    expect(() => validateRunId('foo/bar')).toThrow('Invalid runId');
+    expect(() => validateRunId('../etc/passwd')).toThrow('Invalid runId');
+  });
+
+  it('rejects ids with backslashes', () => {
+    expect(() => validateRunId('foo\\bar')).toThrow('Invalid runId');
+  });
+
+  it('rejects double-dot traversal', () => {
+    expect(() => validateRunId('..')).toThrow('Invalid runId');
+  });
+
+  it('rejects null bytes', () => {
+    expect(() => validateRunId('foo\0bar')).toThrow('Invalid runId');
+  });
+
+  it('rejects Windows absolute paths', () => {
+    expect(() => validateRunId('C:evil')).toThrow('Invalid runId');
   });
 });

--- a/scripts/src/tokens/commands/artifacts.test.ts
+++ b/scripts/src/tokens/commands/artifacts.test.ts
@@ -14,28 +14,30 @@ describe('encodeExtensionId', () => {
   it('pins the sensei canonical id mapping', () => {
     // CRITICAL: this exact string is duplicated in .canvas/extension.mjs.
     // If this test fails or you change it, update both places.
+    // Matches the Copilot CLI runtime's encoding (percent-encoding).
     expect(encodeExtensionId(SENSEI_EXTENSION_ID)).toBe(
-      'skill__github.com_spboyer_sensei__sensei'
+      'skill%3Agithub.com%2Fspboyer%2Fsensei%3Asensei'
     );
   });
 
-  it('replaces colons with double underscores', () => {
-    expect(encodeExtensionId('a:b:c')).toBe('a__b__c');
-  });
-
-  it('replaces slashes with single underscores', () => {
-    expect(encodeExtensionId('a/b/c')).toBe('a_b_c');
-  });
-
-  it('lowercases the result', () => {
-    expect(encodeExtensionId('Skill:GitHub.com/Foo/Bar:Baz')).toBe(
-      'skill__github.com_foo_bar__baz'
+  it('is reversible via decodeURIComponent', () => {
+    expect(decodeURIComponent(encodeExtensionId(SENSEI_EXTENSION_ID))).toBe(
+      SENSEI_EXTENSION_ID
     );
+  });
+
+  it('round-trips ids whose components contain underscores (regression)', () => {
+    // The previous __/_ scheme collided here because GitHub repo names
+    // allow underscores (e.g. `my_repo`). Percent-encoding handles this.
+    const id = 'skill:github.com/owner/my_repo:foo';
+    expect(decodeURIComponent(encodeExtensionId(id))).toBe(id);
   });
 
   it('produces only filesystem-safe characters', () => {
     const encoded = encodeExtensionId(SENSEI_EXTENSION_ID);
-    expect(encoded).toMatch(/^[a-z0-9._-]+$/);
+    // %-encoded results are alphanumeric, dot, dash, underscore, tilde,
+    // and percent — all safe on NTFS, APFS, and ext4.
+    expect(encoded).toMatch(/^[A-Za-z0-9._\-~%]+$/);
   });
 });
 
@@ -87,7 +89,7 @@ describe('resolveArtifactsDir', () => {
   it('computes default from COPILOT_HOME + encoded id', () => {
     process.env.COPILOT_HOME = '/tmp/copilot';
     expect(resolveArtifactsDir()).toBe(
-      '/tmp/copilot/extensions/skill__github.com_spboyer_sensei__sensei/artifacts'
+      '/tmp/copilot/extensions/skill%3Agithub.com%2Fspboyer%2Fsensei%3Asensei/artifacts'
     );
   });
 });

--- a/scripts/src/tokens/commands/artifacts.ts
+++ b/scripts/src/tokens/commands/artifacts.ts
@@ -78,8 +78,32 @@ export function resolveArtifactsDir(override?: string): string {
   );
 }
 
+/**
+ * Validate a runId to prevent path traversal.
+ *
+ * A runId is an opaque caller-supplied identifier (often a ULID, but the
+ * format is not enforced). We only require that it cannot escape the runs/
+ * directory: no path separators, no `..`, no absolute paths, no null bytes.
+ *
+ * Throws if the runId is invalid.
+ */
+export function validateRunId(runId: string): void {
+  if (
+    !runId ||
+    runId.includes('/') ||
+    runId.includes('\\') ||
+    runId.includes('\0') ||
+    runId === '..' ||
+    runId === '.' ||
+    /^[a-zA-Z]:/.test(runId) // absolute Windows path
+  ) {
+    throw new Error(`Invalid runId: ${JSON.stringify(runId)}`);
+  }
+}
+
 /** Path to a specific run's directory under the artifacts root. */
 export function resolveRunDir(artifactsDir: string, runId: string): string {
+  validateRunId(runId);
   return join(artifactsDir, 'runs', runId);
 }
 

--- a/scripts/src/tokens/commands/artifacts.ts
+++ b/scripts/src/tokens/commands/artifacts.ts
@@ -1,0 +1,83 @@
+/**
+ * Artifact path resolution for the sensei canvas.
+ *
+ * Sensei writes per-run artifacts (steps NDJSON + final report.md) into a
+ * well-known directory that the canvas provider (.canvas/extension.mjs)
+ * watches. Layout:
+ *
+ *   <artifactsDir>/runs/<ULID>/manifest.json
+ *   <artifactsDir>/runs/<ULID>/steps.ndjson
+ *   <artifactsDir>/runs/<ULID>/report.md
+ *   <artifactsDir>/runs/latest.txt           (text file: contains the latest ULID)
+ *
+ * `<artifactsDir>` resolution, in priority order:
+ *   1. `--artifacts-dir <path>` CLI flag
+ *   2. `COPILOT_EXTENSION_ARTIFACTS_DIR` env var (set by the Copilot CLI
+ *      runtime when it spawns canvas providers; sensei honors it so the
+ *      writer and the provider always agree on the path).
+ *   3. Computed default:
+ *        $COPILOT_HOME/extensions/<encoded-id>/artifacts
+ *      where:
+ *        - $COPILOT_HOME defaults to $HOME/.copilot
+ *        - <encoded-id> is `encodeExtensionId(SENSEI_EXTENSION_ID)`
+ *
+ * The encoding scheme matches the one proposed in plan-sensei-v2.md §D so
+ * that paths are valid on Windows NTFS, macOS APFS, and Linux ext4:
+ *   ':' → '__'   (double underscore — never appears in a canonical id)
+ *   '/' → '_'    (single underscore)
+ *   lowercase    (avoids case-collision on case-insensitive filesystems)
+ *
+ * The mapping is reversible because `_` is not legal in a GitHub
+ * host/owner/repo component, so the inverse is unambiguous.
+ *
+ * A near-identical copy of `encodeExtensionId` lives in
+ * `.canvas/extension.mjs` (no cross-package import between the CLI and
+ * the canvas provider). The two are kept in sync via the unit test here
+ * pinning the canonical mapping.
+ */
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/** Canonical extension id for sensei. */
+export const SENSEI_EXTENSION_ID = 'skill:github.com/spboyer/sensei:sensei';
+
+/**
+ * Encode a canonical extension id into a filesystem-safe directory name.
+ *
+ * Example:
+ *   encodeExtensionId('skill:github.com/spboyer/sensei:sensei')
+ *     === 'skill__github.com_spboyer_sensei__sensei'
+ */
+export function encodeExtensionId(id: string): string {
+  return id.replace(/:/g, '__').replace(/\//g, '_').toLowerCase();
+}
+
+/** Resolve $COPILOT_HOME (defaults to $HOME/.copilot). */
+export function resolveCopilotHome(): string {
+  return process.env.COPILOT_HOME ?? join(homedir(), '.copilot');
+}
+
+/** Resolve the sensei artifacts directory per the priority order above. */
+export function resolveArtifactsDir(override?: string): string {
+  if (override) return override;
+  if (process.env.COPILOT_EXTENSION_ARTIFACTS_DIR) {
+    return process.env.COPILOT_EXTENSION_ARTIFACTS_DIR;
+  }
+  return join(
+    resolveCopilotHome(),
+    'extensions',
+    encodeExtensionId(SENSEI_EXTENSION_ID),
+    'artifacts'
+  );
+}
+
+/** Path to a specific run's directory under the artifacts root. */
+export function resolveRunDir(artifactsDir: string, runId: string): string {
+  return join(artifactsDir, 'runs', runId);
+}
+
+/** Path to the `latest.txt` pointer (plain text file containing the latest runId). */
+export function resolveLatestPointerPath(artifactsDir: string): string {
+  return join(artifactsDir, 'runs', 'latest.txt');
+}

--- a/scripts/src/tokens/commands/artifacts.ts
+++ b/scripts/src/tokens/commands/artifacts.ts
@@ -11,29 +11,30 @@
  *   <artifactsDir>/runs/latest.txt           (text file: contains the latest ULID)
  *
  * `<artifactsDir>` resolution, in priority order:
- *   1. `--artifacts-dir <path>` CLI flag
- *   2. `COPILOT_EXTENSION_ARTIFACTS_DIR` env var (set by the Copilot CLI
- *      runtime when it spawns canvas providers; sensei honors it so the
- *      writer and the provider always agree on the path).
- *   3. Computed default:
+ *   1. `--artifacts-dir <path>` CLI flag (tests, dev).
+ *   2. `COPILOT_EXTENSION_ARTIFACTS_DIR` env var. The Copilot CLI runtime
+ *      always sets this when it spawns canvas providers, so in
+ *      production the writer and the provider always agree on the path.
+ *      Providers and the CLI never derive it themselves in production.
+ *   3. Computed default (standalone / dev fallback only):
  *        $COPILOT_HOME/extensions/<encoded-id>/artifacts
- *      where:
- *        - $COPILOT_HOME defaults to $HOME/.copilot
- *        - <encoded-id> is `encodeExtensionId(SENSEI_EXTENSION_ID)`
+ *      where `<encoded-id>` is `encodeExtensionId(SENSEI_EXTENSION_ID)`.
  *
- * The encoding scheme matches the one proposed in plan-sensei-v2.md §D so
- * that paths are valid on Windows NTFS, macOS APFS, and Linux ext4:
- *   ':' → '__'   (double underscore — never appears in a canonical id)
- *   '/' → '_'    (single underscore)
- *   lowercase    (avoids case-collision on case-insensitive filesystems)
+ * The encoding used in #3 matches the runtime's scheme — percent-encoding
+ * (`encodeURIComponent`). It's RFC-defined, fully reversible, and safe
+ * on Windows NTFS, macOS APFS, and Linux ext4 (`%` is legal in path
+ * components on all three).
  *
- * The mapping is reversible because `_` is not legal in a GitHub
- * host/owner/repo component, so the inverse is unambiguous.
+ * Why this matters: a previous iteration used a hand-rolled `:` → `__`,
+ * `/` → `_`, lowercase scheme. That scheme isn't reversible in the
+ * general case because GitHub repo names allow `_` (e.g. `my_repo`),
+ * which would collide with a slash-encoded boundary. Percent-encoding
+ * avoids the ambiguity.
  *
  * A near-identical copy of `encodeExtensionId` lives in
  * `.canvas/extension.mjs` (no cross-package import between the CLI and
- * the canvas provider). The two are kept in sync via the unit test here
- * pinning the canonical mapping.
+ * the canvas provider). The two are kept in sync via the unit test in
+ * `artifacts.test.ts` pinning the canonical mapping.
  */
 
 import { homedir } from 'node:os';
@@ -45,12 +46,17 @@ export const SENSEI_EXTENSION_ID = 'skill:github.com/spboyer/sensei:sensei';
 /**
  * Encode a canonical extension id into a filesystem-safe directory name.
  *
+ * Matches the Copilot CLI runtime's encoding (percent-encoding via
+ * `encodeURIComponent`) so dev/test paths line up with what the runtime
+ * would compute. In production, providers and the CLI both read
+ * `COPILOT_EXTENSION_ARTIFACTS_DIR` and never call this function.
+ *
  * Example:
  *   encodeExtensionId('skill:github.com/spboyer/sensei:sensei')
- *     === 'skill__github.com_spboyer_sensei__sensei'
+ *     === 'skill%3Agithub.com%2Fspboyer%2Fsensei%3Asensei'
  */
 export function encodeExtensionId(id: string): string {
-  return id.replace(/:/g, '__').replace(/\//g, '_').toLowerCase();
+  return encodeURIComponent(id);
 }
 
 /** Resolve $COPILOT_HOME (defaults to $HOME/.copilot). */

--- a/scripts/src/tokens/commands/index.ts
+++ b/scripts/src/tokens/commands/index.ts
@@ -2,5 +2,7 @@ export { count } from './count.js';
 export { check } from './check.js';
 export { suggest } from './suggest.js';
 export { compare } from './compare.js';
+export { step } from './step.js';
+export { report } from './report.js';
 export * from './score.js';
 export * from './types.js';

--- a/scripts/src/tokens/commands/report.test.ts
+++ b/scripts/src/tokens/commands/report.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, writeFileSync, existsSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
+import { report, renderReportMarkdown, RunSummary } from './report.js';
+import { step } from './step.js';
+
+describe('renderReportMarkdown', () => {
+  it('renders the minimal summary with a heading and metadata', () => {
+    const md = renderReportMarkdown({ title: 'My Run' }, '01ULID');
+    expect(md).toContain('# My Run');
+    expect(md).toContain('`01ULID`');
+    expect(md).toContain('**Finished:**');
+  });
+
+  it('renders the per-skill table when skills are present', () => {
+    const md = renderReportMarkdown(
+      {
+        title: 'T',
+        skills: [
+          {
+            name: 'pdf',
+            before: { score: 'Low', tokens: 100 },
+            after: { score: 'Medium-High', tokens: 380 },
+            decision: 'commit',
+          },
+        ],
+      },
+      '01U'
+    );
+    expect(md).toContain('| Skill | Before | After | Tokens | Decision |');
+    expect(md).toContain('| `pdf` | Low | Medium-High | 100 → 380 | commit |');
+  });
+
+  it('omits the skills section when there are none', () => {
+    const md = renderReportMarkdown({ title: 'T' }, '01U');
+    expect(md).not.toContain('## Skills');
+  });
+
+  it('shows em-dash placeholders for missing fields', () => {
+    const md = renderReportMarkdown(
+      { skills: [{ name: 'foo' }] },
+      '01U'
+    );
+    expect(md).toContain('| `foo` | — | — | — | — |');
+  });
+
+  it('appends a Notes subsection when any skill has notes', () => {
+    const md = renderReportMarkdown(
+      { skills: [{ name: 'foo', notes: 'tricky' }] },
+      '01U'
+    );
+    expect(md).toContain('### Notes');
+    expect(md).toContain('- **foo** — tricky');
+  });
+
+  it('appends a free-form summary section when provided', () => {
+    const md = renderReportMarkdown({ notes: 'all good' }, '01U');
+    expect(md).toContain('## Summary');
+    expect(md).toContain('all good');
+  });
+});
+
+describe('sensei report --finalize', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'sensei-report-'));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function writeInput(payload: RunSummary): string {
+    const p = join(tmp, 'input.json');
+    writeFileSync(p, JSON.stringify(payload), 'utf8');
+    return p;
+  }
+
+  it('writes report.md, updates manifest, and points latest.txt at the run', async () => {
+    const inputPath = writeInput({ title: 'Hello', skills: [{ name: 'pdf' }] });
+    await report({
+      runId: '01FIN',
+      input: inputPath,
+      artifactsDir: tmp,
+    });
+    const runDir = join(tmp, 'runs', '01FIN');
+    expect(readFileSync(join(runDir, 'report.md'), 'utf8')).toContain('# Hello');
+    const manifest = JSON.parse(readFileSync(join(runDir, 'manifest.json'), 'utf8'));
+    expect(manifest.finishedAt).toBeTruthy();
+    expect(manifest.summary.title).toBe('Hello');
+    expect(readFileSync(join(tmp, 'runs', 'latest.txt'), 'utf8')).toBe('01FIN');
+  });
+
+  it('preserves startedAt from a manifest seeded by sensei step', async () => {
+    await step({ runId: '01M', append: '{"x":1}', artifactsDir: tmp });
+    const before = JSON.parse(
+      readFileSync(join(tmp, 'runs', '01M', 'manifest.json'), 'utf8')
+    );
+    await new Promise((r) => setTimeout(r, 5));
+    await report({
+      runId: '01M',
+      input: writeInput({ title: 'After steps' }),
+      artifactsDir: tmp,
+    });
+    const after = JSON.parse(
+      readFileSync(join(tmp, 'runs', '01M', 'manifest.json'), 'utf8')
+    );
+    expect(after.startedAt).toBe(before.startedAt);
+    expect(after.finishedAt).toBeTruthy();
+    expect(after.finishedAt).not.toBe(after.startedAt);
+  });
+
+  it('reads input from stdin when --input is "-"', async () => {
+    const stdin = Readable.from([JSON.stringify({ title: 'Piped' })]);
+    await report({ runId: '01P', input: '-', artifactsDir: tmp, stdin });
+    expect(readFileSync(join(tmp, 'runs', '01P', 'report.md'), 'utf8')).toContain(
+      '# Piped'
+    );
+  });
+
+  it('requires --run-id and --input', async () => {
+    await expect(report({ input: 'x', artifactsDir: tmp })).rejects.toThrow(/--run-id/);
+    await expect(report({ runId: '01', artifactsDir: tmp })).rejects.toThrow(/--input/);
+  });
+
+  it('rejects invalid JSON input', async () => {
+    const p = join(tmp, 'bad.json');
+    writeFileSync(p, 'not json', 'utf8');
+    await expect(
+      report({ runId: '01R', input: p, artifactsDir: tmp })
+    ).rejects.toThrow(/not valid JSON/);
+  });
+});

--- a/scripts/src/tokens/commands/report.ts
+++ b/scripts/src/tokens/commands/report.ts
@@ -1,0 +1,183 @@
+/**
+ * `sensei report --finalize` — write the final markdown report for a run
+ * and mark the run complete.
+ *
+ * Inputs:
+ *   --run-id <ulid>             ULID of the run to finalize. Required.
+ *   --input <path|->            JSON file (or stdin if '-') with the run
+ *                               summary. Required.
+ *   --artifacts-dir <path>      Override the artifacts directory (tests).
+ *
+ * The JSON input is the structured summary the agent collected during the
+ * Ralph loop. Sensei is the canonical place that knows how to render that
+ * into markdown — keeping the templating in TypeScript means tests can
+ * pin the output and the iframe doesn't have to ship a templating engine.
+ *
+ * Side effects:
+ *   - Writes `<runDir>/report.md` (overwrites if present).
+ *   - Updates `<runDir>/manifest.json` with `finishedAt` + the input
+ *     summary embedded under `summary`.
+ *   - Updates `runs/latest.txt` to point at this runId so canvases that
+ *     open after the fact land on this run by default.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import {
+  resolveArtifactsDir,
+  resolveLatestPointerPath,
+  resolveRunDir,
+} from './artifacts.js';
+
+export interface ReportOptions {
+  runId?: string;
+  /** Path to a JSON file, or '-' to read stdin. */
+  input?: string;
+  /** Override the artifacts directory (mainly for testing). */
+  artifactsDir?: string;
+  /** Stdin stream for testing; defaults to process.stdin. */
+  stdin?: NodeJS.ReadableStream;
+}
+
+/** Shape of the summary JSON the agent passes via --input. */
+export interface RunSummary {
+  /** Display title for the run, e.g. "sensei run on pdf, xlsx". */
+  title?: string;
+  /** Optional mode marker (normal/fast/gepa). */
+  mode?: string;
+  /** Per-skill outcomes. */
+  skills?: Array<{
+    name: string;
+    before?: { score?: string; tokens?: number };
+    after?: { score?: string; tokens?: number };
+    decision?: 'commit' | 'issue' | 'skip' | string;
+    notes?: string;
+  }>;
+  /** Optional free-form summary text appended after the per-skill section. */
+  notes?: string;
+}
+
+function readStdin(stream: NodeJS.ReadableStream): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    stream.on('data', (c) => chunks.push(typeof c === 'string' ? Buffer.from(c) : c));
+    stream.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    stream.on('error', reject);
+  });
+}
+
+function writeLatestPointer(latestPath: string, runId: string): void {
+  const tmp = `${latestPath}.${process.pid}.tmp`;
+  writeFileSync(tmp, runId, 'utf8');
+  renameSync(tmp, latestPath);
+}
+
+/**
+ * Render a run summary as the canonical sensei report.md.
+ *
+ * Exported so unit tests can pin the format without going through the
+ * filesystem, and so other tooling can reuse it.
+ */
+export function renderReportMarkdown(summary: RunSummary, runId: string): string {
+  const lines: string[] = [];
+  lines.push(`# ${summary.title ?? 'Sensei Run'}`);
+  lines.push('');
+  lines.push(`- **Run ID:** \`${runId}\``);
+  if (summary.mode) lines.push(`- **Mode:** ${summary.mode}`);
+  lines.push(`- **Finished:** ${new Date().toISOString()}`);
+  lines.push('');
+
+  const skills = summary.skills ?? [];
+  if (skills.length > 0) {
+    lines.push('## Skills');
+    lines.push('');
+    lines.push('| Skill | Before | After | Tokens | Decision |');
+    lines.push('|---|---|---|---|---|');
+    for (const s of skills) {
+      const before = s.before?.score ?? '—';
+      const after = s.after?.score ?? '—';
+      const tokens =
+        s.before?.tokens != null && s.after?.tokens != null
+          ? `${s.before.tokens} → ${s.after.tokens}`
+          : s.after?.tokens != null
+            ? String(s.after.tokens)
+            : '—';
+      const decision = s.decision ?? '—';
+      lines.push(`| \`${s.name}\` | ${before} | ${after} | ${tokens} | ${decision} |`);
+    }
+    lines.push('');
+
+    const withNotes = skills.filter((s) => s.notes);
+    if (withNotes.length > 0) {
+      lines.push('### Notes');
+      lines.push('');
+      for (const s of withNotes) {
+        lines.push(`- **${s.name}** — ${s.notes}`);
+      }
+      lines.push('');
+    }
+  }
+
+  if (summary.notes) {
+    lines.push('## Summary');
+    lines.push('');
+    lines.push(summary.notes);
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+export async function report(options: ReportOptions): Promise<void> {
+  if (!options.runId) {
+    throw new Error('sensei report: --run-id is required.');
+  }
+  if (!options.input) {
+    throw new Error('sensei report: --input <path|-> is required.');
+  }
+
+  const raw =
+    options.input === '-'
+      ? await readStdin(options.stdin ?? process.stdin)
+      : readFileSync(options.input, 'utf8');
+
+  let summary: RunSummary;
+  try {
+    summary = JSON.parse(raw) as RunSummary;
+  } catch (err) {
+    throw new Error(`Report input is not valid JSON: ${(err as Error).message}`);
+  }
+
+  const artifactsDir = resolveArtifactsDir(options.artifactsDir);
+  const runDir = resolveRunDir(artifactsDir, options.runId);
+  const latestPath = resolveLatestPointerPath(artifactsDir);
+
+  mkdirSync(runDir, { recursive: true });
+
+  // Update or seed manifest. We read the existing one if present so we
+  // preserve `startedAt` from `sensei step` (Phase 2). In Phase 1, where
+  // only `sensei report` runs, we seed it here.
+  const manifestPath = join(runDir, 'manifest.json');
+  const existing = existsSync(manifestPath)
+    ? (JSON.parse(readFileSync(manifestPath, 'utf8')) as Record<string, unknown>)
+    : { runId: options.runId, startedAt: new Date().toISOString(), schemaVersion: 1 };
+  const merged = {
+    ...existing,
+    runId: options.runId,
+    finishedAt: new Date().toISOString(),
+    summary,
+  };
+  writeFileSync(manifestPath, JSON.stringify(merged, null, 2), 'utf8');
+
+  writeFileSync(join(runDir, 'report.md'), renderReportMarkdown(summary, options.runId), 'utf8');
+
+  // Make sure latest.txt points at this run (idempotent if step already did).
+  mkdirSync(join(artifactsDir, 'runs'), { recursive: true });
+  writeLatestPointer(latestPath, options.runId);
+}

--- a/scripts/src/tokens/commands/score.test.ts
+++ b/scripts/src/tokens/commands/score.test.ts
@@ -390,6 +390,22 @@ describe('checkAllowedFields', () => {
     const result = checkAllowedFields(fields);
     expect(result.status).toBe('ok');
   });
+
+  it('allows canvas field (Copilot CLI runtime extension)', () => {
+    const fields = { name: 'x', description: 'y', canvas: true };
+    const result = checkAllowedFields(fields);
+    expect(result.status).toBe('ok');
+  });
+
+  it('allows canvas field with object form', () => {
+    const fields = {
+      name: 'x',
+      description: 'y',
+      canvas: { entry: './.canvas/extension.mjs', id: 'report' }
+    };
+    const result = checkAllowedFields(fields);
+    expect(result.status).toBe('ok');
+  });
 });
 
 describe('checkNameCompliance', () => {

--- a/scripts/src/tokens/commands/score.test.ts
+++ b/scripts/src/tokens/commands/score.test.ts
@@ -391,20 +391,25 @@ describe('checkAllowedFields', () => {
     expect(result.status).toBe('ok');
   });
 
-  it('allows canvas field (Copilot CLI runtime extension)', () => {
-    const fields = { name: 'x', description: 'y', canvas: true };
+  it('accepts canvas opt-in nested under metadata.copilot.canvas', () => {
+    // Sensei's own SKILL.md uses metadata.copilot.canvas to opt into the
+    // Copilot CLI canvas convention without introducing a top-level
+    // non-spec field. The scorer only checks top-level keys; metadata's
+    // inner shape is free-form per the spec.
+    const fields = {
+      name: 'x',
+      description: 'y',
+      metadata: { copilot: { canvas: true } },
+    };
     const result = checkAllowedFields(fields);
     expect(result.status).toBe('ok');
   });
 
-  it('allows canvas field with object form', () => {
-    const fields = {
-      name: 'x',
-      description: 'y',
-      canvas: { entry: './.canvas/extension.mjs', id: 'report' }
-    };
+  it('warns on a top-level canvas field (use metadata.copilot.canvas instead)', () => {
+    const fields = { name: 'x', description: 'y', canvas: true };
     const result = checkAllowedFields(fields);
-    expect(result.status).toBe('ok');
+    expect(result.status).toBe('warning');
+    expect(result.message).toContain('canvas');
   });
 });
 

--- a/scripts/src/tokens/commands/score.test.ts
+++ b/scripts/src/tokens/commands/score.test.ts
@@ -405,6 +405,47 @@ describe('checkAllowedFields', () => {
     expect(result.status).toBe('ok');
   });
 
+  // M3 (flagged by cross-repo rubber-duck review): pin the full value
+  // space accepted under metadata.copilot.canvas so a future scorer
+  // change that constrains `metadata` fails loud against sensei's own
+  // opt-in. The Copilot CLI runtime's discovery parser accepts boolean,
+  // object, and array shapes with identical semantics; the scorer must
+  // not reject any of them.
+  it('accepts metadata.copilot.canvas as a boolean (M3)', () => {
+    const fields = {
+      name: 'x',
+      description: 'y',
+      metadata: { copilot: { canvas: true } },
+    };
+    expect(checkAllowedFields(fields).status).toBe('ok');
+  });
+
+  it('accepts metadata.copilot.canvas as an object (M3)', () => {
+    const fields = {
+      name: 'x',
+      description: 'y',
+      metadata: {
+        copilot: {
+          canvas: { entry: './.canvas/extension.mjs', id: 'report' },
+        },
+      },
+    };
+    expect(checkAllowedFields(fields).status).toBe('ok');
+  });
+
+  it('accepts metadata.copilot.canvas as an array (M3)', () => {
+    const fields = {
+      name: 'x',
+      description: 'y',
+      metadata: {
+        copilot: {
+          canvas: [{ id: 'progress' }, { id: 'report' }],
+        },
+      },
+    };
+    expect(checkAllowedFields(fields).status).toBe('ok');
+  });
+
   it('warns on a top-level canvas field (use metadata.copilot.canvas instead)', () => {
     const fields = { name: 'x', description: 'y', canvas: true };
     const result = checkAllowedFields(fields);

--- a/scripts/src/tokens/commands/score.ts
+++ b/scripts/src/tokens/commands/score.ts
@@ -18,9 +18,25 @@ const MAX_DESCRIPTION_LENGTH = 1024;
 /** Max compatibility field length per agentskills.io spec */
 const MAX_COMPATIBILITY_LENGTH = 500;
 
-/** Allowed frontmatter fields per agentskills.io spec */
+/**
+ * Allowed frontmatter fields per agentskills.io spec, plus known
+ * runtime-specific extensions.
+ *
+ * `canvas` is a Copilot CLI runtime extension to the agentskills.io spec:
+ * skills that opt in by setting `canvas: true` (or providing a canvas
+ * object/array) ship a side-panel UI alongside the chat output. The field
+ * is not part of the agentskills.io spec today; we accept it here so
+ * canvas-bearing skills (including sensei itself) don't trip the
+ * unknown-fields advisory check while the convention is being adopted
+ * upstream.
+ *
+ * If/when the spec adds `canvas`, this comment can be removed and the
+ * field stays in the set.
+ */
 const ALLOWED_FIELDS = new Set([
-  'name', 'description', 'license', 'allowed-tools', 'metadata', 'compatibility'
+  'name', 'description', 'license', 'allowed-tools', 'metadata', 'compatibility',
+  // Copilot CLI runtime extension (see comment above):
+  'canvas'
 ]);
 
 /** Recursively list all files in a directory (Node 18 compatible) */

--- a/scripts/src/tokens/commands/score.ts
+++ b/scripts/src/tokens/commands/score.ts
@@ -18,25 +18,9 @@ const MAX_DESCRIPTION_LENGTH = 1024;
 /** Max compatibility field length per agentskills.io spec */
 const MAX_COMPATIBILITY_LENGTH = 500;
 
-/**
- * Allowed frontmatter fields per agentskills.io spec, plus known
- * runtime-specific extensions.
- *
- * `canvas` is a Copilot CLI runtime extension to the agentskills.io spec:
- * skills that opt in by setting `canvas: true` (or providing a canvas
- * object/array) ship a side-panel UI alongside the chat output. The field
- * is not part of the agentskills.io spec today; we accept it here so
- * canvas-bearing skills (including sensei itself) don't trip the
- * unknown-fields advisory check while the convention is being adopted
- * upstream.
- *
- * If/when the spec adds `canvas`, this comment can be removed and the
- * field stays in the set.
- */
+/** Allowed frontmatter fields per agentskills.io spec. */
 const ALLOWED_FIELDS = new Set([
-  'name', 'description', 'license', 'allowed-tools', 'metadata', 'compatibility',
-  // Copilot CLI runtime extension (see comment above):
-  'canvas'
+  'name', 'description', 'license', 'allowed-tools', 'metadata', 'compatibility'
 ]);
 
 /** Recursively list all files in a directory (Node 18 compatible) */

--- a/scripts/src/tokens/commands/step.test.ts
+++ b/scripts/src/tokens/commands/step.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
+import { step } from './step.js';
+
+describe('sensei step', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'sensei-step-'));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('seeds the run dir and manifest on first call', async () => {
+    await step({
+      runId: '01TEST',
+      append: '{"step":"READ","skill":"foo"}',
+      artifactsDir: tmp,
+    });
+    const runDir = join(tmp, 'runs', '01TEST');
+    expect(existsSync(runDir)).toBe(true);
+    const manifest = JSON.parse(readFileSync(join(runDir, 'manifest.json'), 'utf8'));
+    expect(manifest.runId).toBe('01TEST');
+    expect(typeof manifest.startedAt).toBe('string');
+  });
+
+  it('appends one JSON line per call with an auto-stamped timestamp', async () => {
+    await step({ runId: '01R', append: '{"step":"READ"}', artifactsDir: tmp });
+    await step({ runId: '01R', append: '{"step":"SCORE"}', artifactsDir: tmp });
+    const ndjson = readFileSync(join(tmp, 'runs', '01R', 'steps.ndjson'), 'utf8');
+    const lines = ndjson.trim().split('\n');
+    expect(lines).toHaveLength(2);
+    const first = JSON.parse(lines[0]);
+    expect(first.step).toBe('READ');
+    expect(typeof first.t).toBe('string');
+  });
+
+  it('preserves a caller-provided timestamp', async () => {
+    await step({
+      runId: '01R',
+      append: '{"step":"READ","t":"2026-01-01T00:00:00.000Z"}',
+      artifactsDir: tmp,
+    });
+    const line = readFileSync(join(tmp, 'runs', '01R', 'steps.ndjson'), 'utf8').trim();
+    const parsed = JSON.parse(line);
+    expect(parsed.t).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('updates latest.txt atomically to the active runId', async () => {
+    await step({ runId: '01A', append: '{"x":1}', artifactsDir: tmp });
+    expect(readFileSync(join(tmp, 'runs', 'latest.txt'), 'utf8')).toBe('01A');
+    await step({ runId: '01B', append: '{"x":2}', artifactsDir: tmp });
+    expect(readFileSync(join(tmp, 'runs', 'latest.txt'), 'utf8')).toBe('01B');
+  });
+
+  it('reads payload from stdin when --append is "-"', async () => {
+    const stdin = Readable.from(['{"step":"PIPED"}']);
+    await step({ runId: '01P', append: '-', artifactsDir: tmp, stdin });
+    const line = readFileSync(join(tmp, 'runs', '01P', 'steps.ndjson'), 'utf8').trim();
+    expect(JSON.parse(line).step).toBe('PIPED');
+  });
+
+  it('rejects non-JSON payloads', async () => {
+    await expect(
+      step({ runId: '01R', append: 'not json', artifactsDir: tmp })
+    ).rejects.toThrow(/not valid JSON/);
+  });
+
+  it('rejects JSON arrays and primitives', async () => {
+    await expect(
+      step({ runId: '01R', append: '[1,2,3]', artifactsDir: tmp })
+    ).rejects.toThrow(/must be a JSON object/);
+    await expect(
+      step({ runId: '01R', append: '"hi"', artifactsDir: tmp })
+    ).rejects.toThrow(/must be a JSON object/);
+  });
+
+  it('requires --run-id and --append', async () => {
+    await expect(step({ append: '{}', artifactsDir: tmp })).rejects.toThrow(/--run-id/);
+    await expect(step({ runId: '01R', artifactsDir: tmp })).rejects.toThrow(/--append/);
+  });
+
+  it('does not re-seed manifest on subsequent calls (preserves startedAt)', async () => {
+    await step({ runId: '01R', append: '{"x":1}', artifactsDir: tmp });
+    const before = readFileSync(join(tmp, 'runs', '01R', 'manifest.json'), 'utf8');
+    // Spin enough for ISO ms to differ.
+    await new Promise((r) => setTimeout(r, 5));
+    await step({ runId: '01R', append: '{"x":2}', artifactsDir: tmp });
+    const after = readFileSync(join(tmp, 'runs', '01R', 'manifest.json'), 'utf8');
+    expect(after).toBe(before);
+  });
+});

--- a/scripts/src/tokens/commands/step.ts
+++ b/scripts/src/tokens/commands/step.ts
@@ -1,0 +1,134 @@
+/**
+ * `sensei step --append <json>` — record one Ralph-loop step into the
+ * current run's `steps.ndjson`. The canvas provider tails this file and
+ * broadcasts each new line over SSE to the iframe.
+ *
+ * The agent calls this at the end of each numbered Ralph step in SKILL.md
+ * (Phase 2). It must succeed regardless of whether a canvas is open or
+ * trusted — the agent should never branch on canvas availability.
+ *
+ * The command is also responsible for managing the run lifecycle on the
+ * filesystem so callers don't need a separate "begin run" command:
+ *   - On first call for a given runId, the run directory is created and
+ *     `manifest.json` is written.
+ *   - `latest.txt` is atomically replaced to point at this run.
+ *   - Subsequent calls just append a line to `steps.ndjson`.
+ *
+ * Stdin form: when `--append` is `-`, the JSON payload is read from stdin.
+ */
+
+import { existsSync, mkdirSync, writeFileSync, appendFileSync, renameSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  resolveArtifactsDir,
+  resolveLatestPointerPath,
+  resolveRunDir,
+} from './artifacts.js';
+
+export interface StepOptions {
+  /** ULID of the run this step belongs to. Required. */
+  runId?: string;
+  /** JSON payload describing the step outcome. Use '-' to read from stdin. */
+  append?: string;
+  /** Override the artifacts directory (mainly for testing). */
+  artifactsDir?: string;
+  /** Stdin stream for testing; defaults to process.stdin. */
+  stdin?: NodeJS.ReadableStream;
+}
+
+/**
+ * Read all bytes from a stream as UTF-8.
+ *
+ * Used when the `--append` argument is `-`, meaning the JSON payload is
+ * piped in (common case: the agent constructs a large step record and
+ * shell-pipes it to avoid argv-length limits).
+ */
+function readStdin(stream: NodeJS.ReadableStream): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    stream.on('data', (c) => chunks.push(typeof c === 'string' ? Buffer.from(c) : c));
+    stream.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    stream.on('error', reject);
+  });
+}
+
+/**
+ * Validate and normalize a JSON payload from argv or stdin.
+ *
+ * The payload must parse as JSON and serialize back to a single line so
+ * the NDJSON file stays one-record-per-line. We re-serialize rather than
+ * trust the input's whitespace because the caller's shell might have
+ * pretty-printed it.
+ */
+function normalizeStepPayload(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) throw new Error('Empty step payload.');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch (err) {
+    throw new Error(`Step payload is not valid JSON: ${(err as Error).message}`);
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('Step payload must be a JSON object.');
+  }
+  // Stamp a timestamp if the caller didn't provide one — canvas can sort by it.
+  const stamped = { t: new Date().toISOString(), ...(parsed as Record<string, unknown>) };
+  return JSON.stringify(stamped);
+}
+
+/**
+ * Atomically update `latest.txt` so a canvas watching the file never
+ * observes a partial write. We write to a sibling tempfile and rename;
+ * rename is atomic on the same filesystem on macOS, Linux, and Windows.
+ */
+function writeLatestPointer(latestPath: string, runId: string): void {
+  const tmp = `${latestPath}.${process.pid}.tmp`;
+  writeFileSync(tmp, runId, 'utf8');
+  renameSync(tmp, latestPath);
+}
+
+/**
+ * Ensure the run directory exists and seed `manifest.json` on first call.
+ *
+ * Manifest is intentionally minimal — the report.ts command enriches it
+ * on finalize. We use `exists` rather than catching `EEXIST` so concurrent
+ * `sensei step` invocations for the same runId don't race on the seed.
+ */
+function ensureRunSeeded(runDir: string, runId: string): void {
+  if (existsSync(runDir)) return;
+  mkdirSync(runDir, { recursive: true });
+  const manifest = {
+    runId,
+    startedAt: new Date().toISOString(),
+    finishedAt: null as string | null,
+    schemaVersion: 1,
+  };
+  writeFileSync(join(runDir, 'manifest.json'), JSON.stringify(manifest, null, 2), 'utf8');
+}
+
+export async function step(options: StepOptions): Promise<void> {
+  if (!options.runId) {
+    throw new Error('sensei step: --run-id is required.');
+  }
+  if (!options.append) {
+    throw new Error('sensei step: --append <json|-> is required.');
+  }
+
+  const payloadRaw =
+    options.append === '-'
+      ? await readStdin(options.stdin ?? process.stdin)
+      : options.append;
+  const line = normalizeStepPayload(payloadRaw);
+
+  const artifactsDir = resolveArtifactsDir(options.artifactsDir);
+  const runDir = resolveRunDir(artifactsDir, options.runId);
+  const latestPath = resolveLatestPointerPath(artifactsDir);
+
+  // Ensure the runs/ parent exists for latest.txt before either write.
+  mkdirSync(join(artifactsDir, 'runs'), { recursive: true });
+  ensureRunSeeded(runDir, options.runId);
+
+  appendFileSync(join(runDir, 'steps.ndjson'), line + '\n', 'utf8');
+  writeLatestPointer(latestPath, options.runId);
+}

--- a/scripts/src/tokens/commands/step.ts
+++ b/scripts/src/tokens/commands/step.ts
@@ -17,7 +17,7 @@
  * Stdin form: when `--append` is `-`, the JSON payload is read from stdin.
  */
 
-import { existsSync, mkdirSync, writeFileSync, appendFileSync, renameSync } from 'node:fs';
+import { mkdirSync, writeFileSync, appendFileSync, renameSync } from 'node:fs';
 import { join } from 'node:path';
 import {
   resolveArtifactsDir,
@@ -92,11 +92,12 @@ function writeLatestPointer(latestPath: string, runId: string): void {
  * Ensure the run directory exists and seed `manifest.json` on first call.
  *
  * Manifest is intentionally minimal — the report.ts command enriches it
- * on finalize. We use `exists` rather than catching `EEXIST` so concurrent
- * `sensei step` invocations for the same runId don't race on the seed.
+ * on finalize. We always mkdirSync (idempotent) and write manifest.json
+ * with the `wx` (exclusive-create) flag so concurrent `sensei step`
+ * invocations for the same runId don't race: the second writer gets
+ * EEXIST and silently skips — the first writer's startedAt is preserved.
  */
 function ensureRunSeeded(runDir: string, runId: string): void {
-  if (existsSync(runDir)) return;
   mkdirSync(runDir, { recursive: true });
   const manifest = {
     runId,
@@ -104,7 +105,16 @@ function ensureRunSeeded(runDir: string, runId: string): void {
     finishedAt: null as string | null,
     schemaVersion: 1,
   };
-  writeFileSync(join(runDir, 'manifest.json'), JSON.stringify(manifest, null, 2), 'utf8');
+  try {
+    writeFileSync(
+      join(runDir, 'manifest.json'),
+      JSON.stringify(manifest, null, 2),
+      { encoding: 'utf8', flag: 'wx' }
+    );
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+    // Already seeded by a concurrent writer — that's fine.
+  }
 }
 
 export async function step(options: StepOptions): Promise<void> {


### PR DESCRIPTION
Adds a Copilot CLI canvas to sensei so users get a live side-panel view of the Ralph loop's progress and a browsable report on completion. This PR also makes sensei the reference implementation of the **skill-bundled canvas** convention being co-designed in `github/github-app` and `github/copilot-agent-runtime`.

## What ships

**Phase 1 — Final report:** `.canvas/` iframe + `sensei report --finalize` CLI.
**Phase 2 — Live progress:** `sensei step --append` CLI + SKILL.md hooks streaming each Ralph step to the canvas.

The canvas is fed by **CLI writes + file watcher**, not by canvas RPC actions. The chat agent invokes `sensei step` / `sensei report` like any other shell command; the canvas provider tails the artifact directory and broadcasts via Server-Sent Events. No agent-side branching on "is the canvas open/trusted?", crash-safe, no new RPC surface to spec or version.

## Commits (atomic, reviewable in order)

| SHA | What |
|---|---|
| `77f9f2b` | Phase 1 CLI primitives: `sensei step`, `sensei report --finalize`, `artifacts.ts` path helper, allow-list change for top-level `canvas:` (later reverted), 22 new vitest cases. |
| `5cfb6e9` | `.canvas/` provider (HTTP/SSE + file watcher), iframe (idle/running/report views), Phase 2 SKILL.md hook for per-step writes, `references/canvas.md`, README + AGENTS updates. |
| `65f2e0c` | Migrate frontmatter to `metadata.copilot.canvas: true`; revert ALLOWED_FIELDS whitelist (sensei is the spec enforcer, shouldn't grant itself an exception); add `.gitattributes` `export-ignore` for canvas content. |
| `58dd4f2` | Document the step-payload JSON Schema in `references/canvas.md` so other skills building a canvas the same way have a copy-friendly contract. |
| `81c337c` | Align `encodeExtensionId` with the runtime's chosen percent-encoding scheme (matters only for the dev/test fallback path — production reads `COPILOT_EXTENSION_ARTIFACTS_DIR`). |

Recommendation: **merge without squash** — each commit is a distinct semantic unit (primitives → wiring → frontmatter migration → docs → encoding alignment). This matches the cross-repo planner's recommendation.

## Architecture at a glance

```
chat agent ──▶ npx @spboyer/sensei step  ──┐
chat agent ──▶ npx @spboyer/sensei report ─┤
                                            ▼
                          $COPILOT_HOME/extensions/
                            <encoded-id>/artifacts/runs/<ULID>/
                              {steps.ndjson, report.md}
                                            ▲
                          .canvas/extension.mjs (fs.watch + HTTP/SSE)
                                            ▼
                                    iframe (index.html + app.js)
```

## Frontmatter convention

```yaml
metadata:
  copilot:
    canvas: true
```

Nested under `metadata` rather than top-level so sensei stays strict-spec-compliant (the agentskills.io spec allows `metadata` with free-form inner shape; a top-level `canvas:` field would be unknown). The Copilot CLI runtime's discovery walker accepts both shapes per parity tests in the runtime PR.

## Artifact layout

```
$COPILOT_HOME/extensions/<encoded-id>/artifacts/
└── runs/
    ├── 01ABCDEF.../
    │   ├── manifest.json
    │   ├── steps.ndjson      # append-only NDJSON
    │   └── report.md         # written at finalize
    └── latest.txt            # plain text file, not a symlink (Windows-friendly)
```

`<encoded-id>` is `encodeURIComponent('skill:github.com/spboyer/sensei:sensei')`. In production both writer and reader read `COPILOT_EXTENSION_ARTIFACTS_DIR` from the env (set by the runtime when it spawns the provider) and never re-derive the path.

## What's deliberately NOT in this PR

- **SDK shim** (`@github/copilot-sdk/extension`). The provider runs as a standalone HTTP/SSE/watcher process until that package ships. TODOs in `.canvas/extension.mjs` mark the integration points.
- **Read-side `sensei report <runId>` / `--latest` / `--json`.** Suggested by the planner; additive; will land in a follow-up.
- **Phase 3** (compare runs, run picker, sparklines, host→agent button channel). Deferred.

## Validation

- 146 vitest pass (`scripts/`).
- `npm run tokens -- check` clean against the new files (`references/canvas.md`: 1802/2000 tokens). Two pre-existing offenders unrelated to this PR.
- `npm run tokens -- score .` is clean — `metadata.copilot.canvas` is spec-compliant with no special-casing.
- Manual smoke test: provider + `sensei step` + `sensei report --finalize` → idle → running → complete transitions visible in the iframe; `/report` endpoint serves rendered markdown.

## Coordinating PRs

- **Copilot CLI runtime PR 3** — adds the dual-shape frontmatter parser, `COPILOT_EXTENSION_ARTIFACTS_DIR` env var, and `metadata.copilot.canvas` discovery. **Required** before this PR is observable end-to-end.
- **github-app planning** — host UX (trust prompt, canvas chooser, defensive loopback URL check). Independent.
- **`@github/copilot-sdk/extension`** — `createCanvas` + `joinSession` + `validateLoopbackToken` helpers. Needed for the SDK shim follow-up; not blocking this PR (provider runs standalone).

Once runtime PR 3 lands and the SDK shim is wired in, sensei becomes the canonical example of the "external CLI writer + file-watcher" canvas pattern in the SDK update-patterns doc.
