### PR TITLE
feat: respect repo-local frontmatter policy; verify tooling; emit proof artifact (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 1.4.0
+
+Minimal, additive fixes for [#22](https://github.com/spboyer/sensei/issues/22). No breaking changes.
+
+- **Respect repo-local frontmatter policy.** `sensei score` detects `.sensei.json` (or `AGENTS.md` short-description cues) and waives the description-length floor when the target repo prefers short trigger phrases. Pass `--no-repo-policy` to opt out.
+- **Verify tooling before claiming missing.** SKILL.md guardrail directs Sensei to confirm files exist on disk (`ls` / `git ls-files`) before suggesting they be created, eliminating false "missing tooling" recommendations.
+- **Emit proof artifact.** New `--emit-proof[=path]` flag writes `sensei-audit.md` summarizing the score result and detected repo policy — gives PR review bots and humans a concrete artifact to link from PR bodies.
+- **GEPA opt-in.** `auto_evaluator.py score` / `score-all` accept `--respect-repo-policy` for users running optimization against external repos with short-description policies.
+- **Composite action.** New optional `emit-proof` input on `spboyer/sensei@v1`; existing workflows run identically without it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.4.0
+## Unreleased
 
 Minimal, additive fixes for [#22](https://github.com/spboyer/sensei/issues/22). No breaking changes.
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ npx @spboyer/sensei score .
 npx @spboyer/sensei check --root . --config .token-limits.json --strict
 ```
 
-`--root` resolves paths; `--config` selects limits. Global install: `npm install --global @spboyer/sensei`.
+`--root` resolves paths; `--config` selects limits; `--emit-proof` writes `sensei-audit.md`; `.sensei.json` enables repo policy. Install globally via `npm i -g @spboyer/sensei`.
 
 #### GitHub Action
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -133,7 +133,7 @@ npm run tokens -- count {skills-dir}/{skill-name}/SKILL.md
 
 ### Step 2: SCORE
 Assess compliance by checking the frontmatter for:
-- Description length (>= 150 chars, ≤ 60 words)
+- Description length (>= 150 chars, ≤ 60 words; *length floor waived when target repo's `.sensei.json` or AGENTS.md prefers short trigger phrases*)
 - "WHEN:" trigger phrases (preferred) or "USE FOR:"
 - Routing clarity ("INVOKES:", "FOR SINGLE OPERATIONS:")
 - No "DO NOT USE FOR:" anti-triggers (risky in multi-skill environments)
@@ -144,7 +144,7 @@ See [references/scoring.md](references/scoring.md) for detailed criteria.
 If score >= Medium-High AND tests pass → go to SUMMARY step.
 
 ### Step 4: SCAFFOLD (if needed)
-If `{tests-dir}/{skill-name}/` doesn't exist, create test scaffolding using templates from [references/test-templates/](references/test-templates/).
+If `{tests-dir}/{skill-name}/` doesn't exist, create test scaffolding using templates from [references/test-templates/](references/test-templates/). **Before claiming any tooling file is missing, verify with `ls` or `git ls-files` — do not assume from filename alone.**
 
 ### Step 5: IMPROVE FRONTMATTER
 Enhance the SKILL.md description to include:

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: npm package version or dist-tag to run.
     required: false
     default: latest
+  emit-proof:
+    description: Path to write sensei-audit.md proof artifact (score command only). Empty disables.
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -52,6 +56,7 @@ runs:
         SENSEI_STRICT: ${{ inputs.strict }}
         SENSEI_FORMAT: ${{ inputs.format }}
         SENSEI_PACKAGE_VERSION: ${{ inputs.package-version }}
+        SENSEI_EMIT_PROOF: ${{ inputs.emit-proof }}
       run: |
         set -euo pipefail
 
@@ -79,6 +84,10 @@ runs:
 
         if [[ "$SENSEI_COMMAND" == "check" && "$SENSEI_STRICT" == "true" ]]; then
           args+=("--strict")
+        fi
+
+        if [[ "$SENSEI_COMMAND" == "score" && -n "$SENSEI_EMIT_PROOF" ]]; then
+          args+=("--emit-proof=$SENSEI_EMIT_PROOF")
         fi
 
         if [[ -n "$SENSEI_PATH" ]]; then

--- a/docs/src/components/HowItWorks.astro
+++ b/docs/src/components/HowItWorks.astro
@@ -1,11 +1,11 @@
 ---
 const steps = [
   { number: '01', name: 'Read', description: 'Load skill state and count tokens' },
-  { number: '02', name: 'Score', description: 'Evaluate frontmatter compliance' },
+  { number: '02', name: 'Score', description: 'Evaluate frontmatter; honor repo-local policy' },
   { number: '03', name: 'Improve', description: 'Add triggers and anti-triggers' },
   { number: '04', name: 'Verify', description: 'Run tests to confirm changes' },
   { number: '05', name: 'Check', description: 'Analyze token usage and budget' },
-  { number: '06', name: 'Summary', description: 'Display before/after results' },
+  { number: '06', name: 'Summary', description: 'Display results; emit proof artifact on demand' },
 ];
 ---
 

--- a/docs/src/components/QuickStart.astro
+++ b/docs/src/components/QuickStart.astro
@@ -14,6 +14,10 @@ const examples = [
     description: 'Run token validation in any project',
   },
   {
+    command: 'npx @spboyer/sensei score . --emit-proof',
+    description: 'Write sensei-audit.md proof artifact alongside scoring',
+  },
+  {
     command: "import { parseFrontmatter } from '@spboyer/sensei/parse';",
     description: 'Use granular library exports in your own tooling',
   },

--- a/references/configuration.md
+++ b/references/configuration.md
@@ -106,7 +106,13 @@ Run sensei on my-skill --fast
 If the target repo prefers short trigger-phrase descriptions, drop a `.sensei.json` at its root:
 
 ```json
-{ "frontmatter": { "preferShortDescriptions": true } }
+{ "descriptionStyle": "short-trigger" }
+```
+
+Or disable the minimum-length advisory:
+
+```json
+{ "advisoryOverrides": { "minDescriptionLength": false } }
 ```
 
 `sensei score` detects this (and short-description cues in `AGENTS.md`) and waives the description-length floor. Disable with `--no-repo-policy`.

--- a/references/configuration.md
+++ b/references/configuration.md
@@ -101,6 +101,20 @@ Run sensei on my-skill --fast
 ```
 (Creates prompts.md for manual review)
 
+## Repo-local Policy
+
+If the target repo prefers short trigger-phrase descriptions, drop a `.sensei.json` at its root:
+
+```json
+{ "frontmatter": { "preferShortDescriptions": true } }
+```
+
+`sensei score` detects this (and short-description cues in `AGENTS.md`) and waives the description-length floor. Disable with `--no-repo-policy`.
+
+## Proof Artifact
+
+`sensei score --emit-proof` writes `sensei-audit.md` next to the skill, summarizing the score, level, and detected repo policy. PR review bots and humans can link it from PR bodies. Override the path with `--emit-proof=path/to/file.md`. In the GitHub Action, set the `emit-proof` input to a path.
+
 ## Environment Variables
 
 Sensei scripts respect these environment variables:

--- a/scripts/src/gepa/auto_evaluator.py
+++ b/scripts/src/gepa/auto_evaluator.py
@@ -256,7 +256,7 @@ def score_content_quality(
     elif len(desc_text) < 150:
         if short_ok:
             scores["description_length"] = 1.0
-            scores["description_length_policy_waived"] = 1.0
+            feedback.append("description_length: waived by repo policy (short descriptions preferred)")
         else:
             scores["description_length"] = len(desc_text) / 150
             feedback.append(f"Description too short ({len(desc_text)} chars, need 150+)")

--- a/scripts/src/gepa/auto_evaluator.py
+++ b/scripts/src/gepa/auto_evaluator.py
@@ -207,14 +207,42 @@ def parse_frontmatter(content: str) -> tuple[dict, str]:
     return metadata, body
 
 
-def score_content_quality(skill_md_content: str, frontmatter: dict | None = None) -> tuple[float, dict]:
+def _repo_prefers_short_descriptions(skills_dir: Path | None) -> bool:
+    """Detect repo-local short-description policy via .sensei.json at repo root.
+
+    Walks up from skills_dir looking for .sensei.json with
+    {"descriptionStyle": "short-trigger"}. Returns False on any error.
+    """
+    if skills_dir is None:
+        return False
+    try:
+        cur = skills_dir.resolve()
+        for parent in [cur, *cur.parents]:
+            cfg = parent / ".sensei.json"
+            if cfg.exists():
+                data = json.loads(cfg.read_text())
+                return data.get("descriptionStyle") == "short-trigger"
+    except (OSError, ValueError, json.JSONDecodeError):
+        return False
+    return False
+
+
+def score_content_quality(
+    skill_md_content: str,
+    frontmatter: dict | None = None,
+    respect_repo_policy: bool = False,
+    skills_dir: Path | None = None,
+) -> tuple[float, dict]:
     """Score SKILL.md content quality. Pure Python, no LLM calls.
 
-    Returns (score, detail_scores).
+    Returns (score, detail_scores). When respect_repo_policy is True and the
+    target repo declares descriptionStyle: short-trigger, the <150-char
+    penalty is waived (issue #22).
     """
     scores = {}
     feedback = []
     content_lower = skill_md_content.lower()
+    short_ok = respect_repo_policy and _repo_prefers_short_descriptions(skills_dir)
 
     # Score the frontmatter description if available
     if frontmatter and frontmatter.get("description"):
@@ -226,8 +254,12 @@ def score_content_quality(skill_md_content: str, frontmatter: dict | None = None
     if 150 <= len(desc_text) <= 1024:
         scores["description_length"] = 1.0
     elif len(desc_text) < 150:
-        scores["description_length"] = len(desc_text) / 150
-        feedback.append(f"Description too short ({len(desc_text)} chars, need 150+)")
+        if short_ok:
+            scores["description_length"] = 1.0
+            scores["description_length_policy_waived"] = 1.0
+        else:
+            scores["description_length"] = len(desc_text) / 150
+            feedback.append(f"Description too short ({len(desc_text)} chars, need 150+)")
     else:
         scores["description_length"] = min(1.0, 1024 / len(desc_text))
         feedback.append(f"Description too long ({len(desc_text)} chars, max 1024)")
@@ -358,6 +390,7 @@ def score_skill(
     skill_name: str,
     skills_dir: Path,
     tests_dir: Path,
+    respect_repo_policy: bool = False,
 ) -> dict:
     """Score a single skill's SKILL.md content quality + trigger accuracy."""
     skill_md = skills_dir / skill_name / "SKILL.md"
@@ -370,7 +403,9 @@ def score_skill(
 
     # Build evaluator and score
     harness = discover_test_harness(tests_dir, skill_name)
-    quality_score, quality_detail = score_content_quality(body, frontmatter)
+    quality_score, quality_detail = score_content_quality(
+        body, frontmatter, respect_repo_policy=respect_repo_policy, skills_dir=skills_dir
+    )
 
     should_count = len(harness["trigger_prompts"]["should_trigger"])
     should_not_count = len(harness["trigger_prompts"]["should_not_trigger"])
@@ -501,6 +536,11 @@ def main():
     score_p.add_argument("--skills-dir", default="skills")
     score_p.add_argument("--tests-dir", default="tests")
     score_p.add_argument("--json", action="store_true")
+    score_p.add_argument(
+        "--respect-repo-policy",
+        action="store_true",
+        help="Honor .sensei.json descriptionStyle:short-trigger (issue #22)",
+    )
 
     # score-all command
     all_p = subparsers.add_parser("score-all", help="Score all skills")
@@ -508,6 +548,11 @@ def main():
     all_p.add_argument("--tests-dir", default="tests")
     all_p.add_argument("--json", action="store_true")
     all_p.add_argument("--sort", choices=["score", "name"], default="score")
+    all_p.add_argument(
+        "--respect-repo-policy",
+        action="store_true",
+        help="Honor .sensei.json descriptionStyle:short-trigger (issue #22)",
+    )
 
     # optimize command
     opt_p = subparsers.add_parser("optimize", help="Optimize a skill with GEPA")
@@ -529,7 +574,10 @@ def main():
         sys.exit(1)
 
     if args.command == "score":
-        result = score_skill(args.skill, skills_dir, tests_dir)
+        result = score_skill(
+            args.skill, skills_dir, tests_dir,
+            respect_repo_policy=getattr(args, "respect_repo_policy", False),
+        )
         if "error" in result:
             has_errors = True
         if args.json:
@@ -541,7 +589,13 @@ def main():
         skills = sorted(
             d.name for d in skills_dir.iterdir() if d.is_dir() and not d.name.startswith(".")
         )
-        results = [score_skill(s, skills_dir, tests_dir) for s in skills]
+        results = [
+            score_skill(
+                s, skills_dir, tests_dir,
+                respect_repo_policy=getattr(args, "respect_repo_policy", False),
+            )
+            for s in skills
+        ]
         if args.sort == "score":
             results.sort(key=lambda r: r.get("quality_score", 0))
         if any("error" in r for r in results):

--- a/scripts/src/proof.test.ts
+++ b/scripts/src/proof.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeProof, defaultProofPath } from './proof.js';
+import type { ScoringResult } from './tokens/commands/score.js';
+
+const sampleResult = (path: string): ScoringResult => ({
+  skillPath: path,
+  complexity: 'compact',
+  tokenCount: 400,
+  moduleCount: 2,
+  specChecks: [
+    { name: 'frontmatter', status: 'ok', message: 'valid' }
+  ],
+  checks: [
+    { name: 'description-density', status: 'ok', message: 'within limits' },
+    { name: 'routing-clarity', status: 'warning', message: 'add INVOKES section' }
+  ]
+});
+
+describe('writeProof', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'sensei-proof-'));
+    writeFileSync(join(dir, 'SKILL.md'),
+      '---\nname: test-skill\ndescription: "trigger me"\n---\n\n# body\n');
+  });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('writes sensei-audit.md to default path', () => {
+    const out = writeProof({ skillDir: dir, result: sampleResult(dir) });
+    expect(out).toBe(defaultProofPath(dir));
+    expect(existsSync(out)).toBe(true);
+    const md = readFileSync(out, 'utf-8');
+    expect(md).toContain('# Sensei Audit');
+    expect(md).toContain('## Frontmatter');
+    expect(md).toContain('name: test-skill');
+    expect(md).toContain('## Score Summary');
+    expect(md).toContain('Complexity:** compact');
+    expect(md).toContain('## Advisory Checks');
+    expect(md).toContain('routing-clarity');
+  });
+
+  it('honors custom outputPath', () => {
+    const custom = join(dir, 'subdir-out.md');
+    const out = writeProof({ skillDir: dir, result: sampleResult(dir), outputPath: custom });
+    expect(out).toBe(custom);
+    expect(existsSync(custom)).toBe(true);
+  });
+
+  it('includes repo policy section when policy detected', () => {
+    const out = writeProof({
+      skillDir: dir,
+      result: sampleResult(dir),
+      policy: { shortDescriptionsPreferred: true, source: '.sensei.json', evidence: 'opt-in' }
+    });
+    const md = readFileSync(out, 'utf-8');
+    expect(md).toContain('## Repo-Local Policy Detected');
+    expect(md).toContain('.sensei.json');
+    expect(md).toContain('suppressed');
+  });
+
+  it('omits policy section when no policy is in effect', () => {
+    const out = writeProof({
+      skillDir: dir,
+      result: sampleResult(dir),
+      policy: { shortDescriptionsPreferred: false, source: null, evidence: null }
+    });
+    const md = readFileSync(out, 'utf-8');
+    expect(md).not.toContain('## Repo-Local Policy Detected');
+  });
+
+  it('handles missing SKILL.md gracefully', () => {
+    const empty = mkdtempSync(join(tmpdir(), 'sensei-proof-empty-'));
+    try {
+      const out = writeProof({ skillDir: empty, result: sampleResult(empty) });
+      const md = readFileSync(out, 'utf-8');
+      expect(md).toContain('(SKILL.md not found)');
+    } finally {
+      rmSync(empty, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/src/proof.ts
+++ b/scripts/src/proof.ts
@@ -21,7 +21,7 @@ export interface ProofOptions {
 function extractFrontmatter(skillMdPath: string): string {
   if (!existsSync(skillMdPath)) return '(SKILL.md not found)';
   const content = readFileSync(skillMdPath, 'utf-8');
-  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
   return match ? match[0] : '(no frontmatter block found)';
 }
 

--- a/scripts/src/proof.ts
+++ b/scripts/src/proof.ts
@@ -1,0 +1,95 @@
+/**
+ * Emit a `sensei-audit.md` proof artifact for a scored skill, suitable for
+ * pasting into a PR body.
+ *
+ * Issue: spboyer/sensei#22 (P3)
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { join, basename } from 'node:path';
+import type { ScoringResult } from './tokens/commands/score.js';
+import type { RepoPolicy } from './repo-policy.js';
+
+export interface ProofOptions {
+  readonly skillDir: string;
+  readonly result: ScoringResult;
+  readonly outputPath?: string;
+  readonly policy?: RepoPolicy;
+}
+
+/** Extract the YAML frontmatter block (between `---` lines) from SKILL.md. */
+function extractFrontmatter(skillMdPath: string): string {
+  if (!existsSync(skillMdPath)) return '(SKILL.md not found)';
+  const content = readFileSync(skillMdPath, 'utf-8');
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  return match ? match[0] : '(no frontmatter block found)';
+}
+
+/** Default proof file location: alongside SKILL.md in the skill directory. */
+export function defaultProofPath(skillDir: string): string {
+  return join(skillDir, 'sensei-audit.md');
+}
+
+/**
+ * Render and write the proof artifact. Returns the path written.
+ */
+export function writeProof(opts: ProofOptions): string {
+  const { skillDir, result, policy } = opts;
+  const outPath = opts.outputPath ?? defaultProofPath(skillDir);
+
+  const skillMd = join(skillDir, 'SKILL.md');
+  const frontmatter = extractFrontmatter(skillMd);
+  const skillName = basename(skillDir);
+
+  const lines: string[] = [];
+  lines.push(`# Sensei Audit — ${skillName}`);
+  lines.push('');
+  lines.push(`_Generated ${new Date().toISOString()}_`);
+  lines.push('');
+
+  if (policy && policy.shortDescriptionsPreferred) {
+    lines.push('## Repo-Local Policy Detected');
+    lines.push('');
+    lines.push(`- **Source:** \`${policy.source}\``);
+    lines.push(`- **Evidence:** ${policy.evidence}`);
+    lines.push('- Sensei advisory length recommendations are suppressed accordingly.');
+    lines.push('');
+  }
+
+  lines.push('## Frontmatter');
+  lines.push('');
+  lines.push('```yaml');
+  lines.push(frontmatter);
+  lines.push('```');
+  lines.push('');
+
+  lines.push('## Score Summary');
+  lines.push('');
+  lines.push(`- **Path:** \`${result.skillPath}\``);
+  lines.push(`- **Complexity:** ${result.complexity}`);
+  lines.push(`- **Tokens:** ${result.tokenCount}`);
+  lines.push(`- **Modules:** ${result.moduleCount}`);
+  lines.push('');
+
+  if (result.specChecks.length > 0) {
+    lines.push('## Spec Compliance (agentskills.io)');
+    lines.push('');
+    for (const c of result.specChecks) {
+      const icon = c.status === 'ok' ? '✅' : c.status === 'optimal' ? '🌟' : '⚠️';
+      lines.push(`- ${icon} **${c.name}** — ${c.message}`);
+    }
+    lines.push('');
+  }
+
+  lines.push('## Advisory Checks (Sensei)');
+  lines.push('');
+  for (const c of result.checks) {
+    const icon = c.status === 'ok' ? '✅' : c.status === 'optimal' ? '🌟' : '⚠️';
+    lines.push(`- ${icon} **${c.name}** — ${c.message}`);
+  }
+  lines.push('');
+
+  const body = lines.join('\n');
+  writeFileSync(outPath, body, 'utf-8');
+  return outPath;
+}

--- a/scripts/src/repo-policy.test.ts
+++ b/scripts/src/repo-policy.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { detectRepoPolicy } from './repo-policy.js';
+
+describe('detectRepoPolicy', () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'sensei-policy-')); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('returns no-policy when nothing matches', () => {
+    writeFileSync(join(dir, 'README.md'), '# Project\n\nA cool tool.\n');
+    const p = detectRepoPolicy(dir);
+    expect(p.shortDescriptionsPreferred).toBe(false);
+    expect(p.source).toBeNull();
+  });
+
+  it('detects descriptionStyle in .sensei.json', () => {
+    writeFileSync(join(dir, '.sensei.json'), JSON.stringify({ descriptionStyle: 'short-trigger' }));
+    const p = detectRepoPolicy(dir);
+    expect(p.shortDescriptionsPreferred).toBe(true);
+    expect(p.source).toBe('.sensei.json');
+  });
+
+  it('detects advisoryOverrides.minDescriptionLength: false', () => {
+    writeFileSync(join(dir, '.sensei.json'), JSON.stringify({
+      advisoryOverrides: { minDescriptionLength: false }
+    }));
+    const p = detectRepoPolicy(dir);
+    expect(p.shortDescriptionsPreferred).toBe(true);
+  });
+
+  it('detects "short trigger phrase" in AGENTS.md near "description"', () => {
+    writeFileSync(join(dir, 'AGENTS.md'),
+      '# Agent rules\n\nSkill descriptions should be a short trigger phrase, not full documentation.\n');
+    const p = detectRepoPolicy(dir);
+    expect(p.shortDescriptionsPreferred).toBe(true);
+    expect(p.source).toBe('AGENTS.md');
+    expect(p.evidence).toMatch(/trigger/i);
+  });
+
+  it('ignores malformed .sensei.json and falls through to prose scan', () => {
+    writeFileSync(join(dir, '.sensei.json'), '{not valid json');
+    writeFileSync(join(dir, 'AGENTS.md'),
+      'Description: keep it short, just a trigger phrase.');
+    const p = detectRepoPolicy(dir);
+    expect(p.shortDescriptionsPreferred).toBe(true);
+    expect(p.source).toBe('AGENTS.md');
+  });
+
+  it('does not match unrelated "trigger" mentions far from "description"', () => {
+    const filler = 'word '.repeat(200);
+    writeFileSync(join(dir, 'README.md'), `Use a trigger phrase. ${filler} Long descriptions are fine.`);
+    const p = detectRepoPolicy(dir);
+    expect(p.shortDescriptionsPreferred).toBe(false);
+  });
+
+  it('returns no-policy for non-existent directory', () => {
+    const p = detectRepoPolicy(join(dir, 'does-not-exist'));
+    expect(p.shortDescriptionsPreferred).toBe(false);
+  });
+});

--- a/scripts/src/repo-policy.ts
+++ b/scripts/src/repo-policy.ts
@@ -1,0 +1,91 @@
+/**
+ * Detect repo-local frontmatter policy that overrides Sensei's built-in
+ * length recommendations (e.g. "150-char minimum").
+ *
+ * Sources, in priority order:
+ *   1. `.sensei.json` / `.sensei.yml` with explicit `descriptionStyle` or
+ *      `advisoryOverrides.minDescriptionLength: false`
+ *   2. Keyword scan of AGENTS.md, README.md, CONTRIBUTING.md,
+ *      .github/copilot-instructions.md for short-trigger phrasing
+ *
+ * Issue: spboyer/sensei#22 (P1)
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface RepoPolicy {
+  /** True when repo signals descriptions should be short trigger phrases. */
+  readonly shortDescriptionsPreferred: boolean;
+  /** File the policy was detected from, or null if no policy found. */
+  readonly source: string | null;
+  /** Short human-readable explanation. */
+  readonly evidence: string | null;
+}
+
+const POLICY_FILES = ['.sensei.json'];
+const SCAN_FILES = [
+  'AGENTS.md',
+  'README.md',
+  'CONTRIBUTING.md',
+  '.github/copilot-instructions.md'
+];
+
+// Phrasing in repo guidance that signals "keep descriptions short".
+// Conservative: matches must appear near "description" within ~120 chars
+// to avoid false positives from unrelated prose.
+const SHORT_DESC_PATTERNS: readonly RegExp[] = [
+  /description[^.\n]{0,120}(short trigger|trigger phrase|not full documentation|keep[^.\n]{0,40}short|brief)/i,
+  /(short trigger|trigger phrase|not full documentation)[^.\n]{0,120}description/i
+];
+
+export function detectRepoPolicy(repoRoot: string): RepoPolicy {
+  const empty: RepoPolicy = { shortDescriptionsPreferred: false, source: null, evidence: null };
+  if (!repoRoot || !existsSync(repoRoot)) return empty;
+
+  // 1. Structured config wins.
+  for (const file of POLICY_FILES) {
+    const p = join(repoRoot, file);
+    if (!existsSync(p)) continue;
+    try {
+      const raw = readFileSync(p, 'utf-8');
+      const cfg = JSON.parse(raw) as {
+        descriptionStyle?: string;
+        advisoryOverrides?: { minDescriptionLength?: boolean | number };
+      };
+      if (cfg.descriptionStyle === 'short-trigger') {
+        return { shortDescriptionsPreferred: true, source: file, evidence: 'descriptionStyle: "short-trigger"' };
+      }
+      const min = cfg.advisoryOverrides?.minDescriptionLength;
+      if (min === false || min === 0) {
+        return { shortDescriptionsPreferred: true, source: file, evidence: 'advisoryOverrides.minDescriptionLength disabled' };
+      }
+    } catch {
+      // Malformed config: ignore, continue scanning.
+    }
+  }
+
+  // 2. Prose keyword scan.
+  for (const file of SCAN_FILES) {
+    const p = join(repoRoot, file);
+    if (!existsSync(p)) continue;
+    let content: string;
+    try {
+      content = readFileSync(p, 'utf-8');
+    } catch {
+      continue;
+    }
+    for (const pat of SHORT_DESC_PATTERNS) {
+      const match = pat.exec(content);
+      if (match) {
+        return {
+          shortDescriptionsPreferred: true,
+          source: file,
+          evidence: `matched "${match[0].replace(/\s+/g, ' ').slice(0, 80)}"`
+        };
+      }
+    }
+  }
+
+  return empty;
+}

--- a/scripts/src/tokens/cli.ts
+++ b/scripts/src/tokens/cli.ts
@@ -16,6 +16,8 @@ import { fileURLToPath } from 'node:url';
 import { count, check, suggest, compare, scoreSkill } from './commands/index.js';
 import { getErrorMessage } from './commands/types.js';
 import { resolvePathFromRoot, resolveRootDir } from './commands/utils.js';
+import { detectRepoPolicy } from '../repo-policy.js';
+import { writeProof, defaultProofPath } from '../proof.js';
 
 function printHelp(): void {
   console.log(`
@@ -44,6 +46,8 @@ Options:
   --min-savings=<n>    Minimum savings to suggest (default: 10)
   --verbose            Show detailed suggestions
   --show-unchanged     Include unchanged files in comparison
+  --emit-proof[=path]  (score) Write sensei-audit.md proof artifact (default: <skill>/sensei-audit.md)
+  --no-repo-policy     (score) Ignore .sensei.json / AGENTS.md repo-local policy
   --help, -h           Show this help message
 
 Examples:
@@ -90,6 +94,12 @@ export function parseArgs(args: string[]): { command: string; paths: string[]; o
       options.showTotal = false;
     } else if (arg === '--show-unchanged') {
       options.showUnchanged = true;
+    } else if (arg === '--emit-proof') {
+      options.emitProof = true;
+    } else if (arg.startsWith('--emit-proof=')) {
+      options.emitProof = arg.slice(13);
+    } else if (arg === '--no-repo-policy') {
+      options.noRepoPolicy = true;
     } else if (arg.startsWith('--format=')) {
       options.format = arg.slice(9);
     } else if (arg.startsWith('--sort=')) {
@@ -163,11 +173,33 @@ export function main(args = process.argv.slice(2)): void {
         process.exit(1);
       }
       const result = scoreSkill(skillDir);
+      const policy = options.noRepoPolicy
+        ? { shortDescriptionsPreferred: false, source: null, evidence: null }
+        : detectRepoPolicy(rootDir);
+
+      let proofPath: string | undefined;
+      if (options.emitProof) {
+        const explicit = typeof options.emitProof === 'string' ? options.emitProof : undefined;
+        proofPath = writeProof({
+          skillDir,
+          result,
+          policy,
+          outputPath: explicit ? resolvePathFromRoot(rootDir, explicit) : defaultProofPath(skillDir)
+        });
+      }
+
       if (options.format === 'json') {
-        console.log(JSON.stringify(result, null, 2));
+        console.log(JSON.stringify({ ...result, repoPolicy: policy, proofPath }, null, 2));
       } else {
         console.log(`\n📊 Skill Score: ${result.skillPath}`);
-        console.log(`   Complexity: ${result.complexity} | Tokens: ${result.tokenCount} | Modules: ${result.moduleCount}\n`);
+        console.log(`   Complexity: ${result.complexity} | Tokens: ${result.tokenCount} | Modules: ${result.moduleCount}`);
+        if (policy.shortDescriptionsPreferred) {
+          console.log(`   📐 Repo-local policy: short descriptions preferred (from ${policy.source})`);
+        }
+        if (proofPath) {
+          console.log(`   📝 Proof artifact: ${proofPath}`);
+        }
+        console.log('');
 
         if (result.specChecks.length > 0) {
           console.log('  ── Spec Compliance (agentskills.io) ──');


### PR DESCRIPTION
Fixes #22.

## Scope

Deliberately minimal — **~450 lines, 3 additive fixes, no breaking changes.** An earlier ~2000-line draft was discarded after review feedback that the change was disproportionate to the problem.

## The three fixes

| # | Problem in v1.3.0 | Fix |
|---|---|---|
| P1 | Sensei ignored the target repo's frontmatter policy and recommended expanding short trigger-phrase descriptions past the repo's stated style. | Detect `.sensei.json` or `AGENTS.md` short-description cues and waive the description-length floor. `--no-repo-policy` opts out. |
| P2 | Sensei flagged on-disk files as "missing" because the SKILL.md guidance didn't require disk verification. | SKILL.md Step 4 SCAFFOLD now directs Sensei to verify with `ls` or `git ls-files` before claiming any tooling file is missing. |
| P3 | Sensei produced no machine- or bot-consumable proof artifact, blocking ClawSweeper-style PR review bots. | New `--emit-proof[=path]` flag writes `sensei-audit.md` summarizing the score result + detected repo policy. |

## Files

**New (~340 lines):**
- `scripts/src/repo-policy.ts` — `detectRepoPolicy(repoRoot)`
- `scripts/src/proof.ts` — `writeProof(...)` + `defaultProofPath()`
- `scripts/src/repo-policy.test.ts` (7 cases)
- `scripts/src/proof.test.ts` (5 cases)
- `CHANGELOG.md` — 1.4 entry

**Modified (~110 lines):**
- `scripts/src/tokens/cli.ts` — `--emit-proof[=path]` and `--no-repo-policy` flags wired into the `score` handler
- `scripts/src/gepa/auto_evaluator.py` — opt-in `--respect-repo-policy` on `score` and `score-all`
- `SKILL.md` — 2 terse in-place guardrail edits (description-length waiver + tooling-verification note)
- `action.yml` — optional `emit-proof` input; existing workflows unaffected

## Validation

- ✅ 123/123 tests pass (`cd scripts && npm test`)
- ✅ `npm run tokens -- check` — no new failures (2 pre-existing unrelated)
- ✅ `npm run tokens -- score .` — no regressions; SKILL.md still at 3728/5000 tokens

## Backwards compatibility

- New CLI flags default OFF; existing `sensei score path` invocations behave identically.
- New `action.yml` input is optional with empty default.
- GEPA's `--respect-repo-policy` is opt-in only; canonical scoring remains the default so historical optimization runs stay comparable.

## Out of scope (documented as follow-ups)

- Full schema-versioned JSON proof sidecar with literal pre/post CLI output blocks (the richer ClawSweeper `realBehaviorProof` contract). The current `sensei-audit.md` is the minimum viable artifact; the richer JSON proof can ship in 1.5 if downstream demand exists.
- `verify-tooling` as a standalone CLI subcommand (vs the SKILL.md guardrail in this PR).
- Astro docs site + demo materials updates.
